### PR TITLE
Реализация генератора кораблей

### DIFF
--- a/Program/battle_interface/BattleInterface.c
+++ b/Program/battle_interface/BattleInterface.c
@@ -1804,7 +1804,7 @@ void SetShipPictureDataByShipTypeName(string sType)
 
 void SetShipPictureDataByShipType(int st)
 {
-	if(st>=0 && st<SHIP_TYPES_QUANTITY)
+	if(st>=0 && st<GetArraySize(&ShipsTypes))
 	{
 		SetShipPictureDataByShipTypeName( ShipsTypes[st].name );
 	}

--- a/Program/battle_interface/utils.c
+++ b/Program/battle_interface/utils.c
@@ -472,7 +472,7 @@ void GetTextureUVForShip(int nShipType, ref rLeft, ref rTop, ref rRight, ref rBo
 	
 //	Log_SetStringToLog("type " + nShipType);
 	
-	if( nShipType> -1 && nShipType<SHIP_TYPES_QUANTITY_WITH_FORT ) // <-- ugeen fix, для тартаны nShipType = 0 !!!!
+	if( nShipType> -1 && nShipType<GetArraySize(&ShipsTypes) ) // <-- ugeen fix, для тартаны nShipType = 0 !!!!
 	{
 		ref rBaseShip = &ShipsTypes[nShipType];
 		SetShipPictureDataByShipTypeName( rBaseShip.name );
@@ -528,7 +528,7 @@ void procTimerTimeOut()
 }
 void InitShipHulls() 
 {
-	for (int shipIndex = 0; shipIndex < SHIP_TYPES_QUANTITY_WITH_FORT; shipIndex++) {
+	for (int shipIndex = 0; shipIndex < GetArraySize(&ShipsTypes); shipIndex++) {
 		ref ship = &ShipsTypes[shipIndex];
 		if (!CheckAttribute(ship, "name")) {
 			continue;

--- a/Program/characters/QuestsUtilite.c
+++ b/Program/characters/QuestsUtilite.c
@@ -5077,39 +5077,44 @@ void SelectLevelWarShipParameter()//Jason автолевеллинг на вое
 	if(sti(pchar.rank) >= 14 && sti(pchar.rank) < 19) iShipRank = 2;
 	if(sti(pchar.rank) >= 7 && sti(pchar.rank) < 14) iShipRank = 1;	
 	if(sti(pchar.rank) < 7) iShipRank = 0;
+	
+	int iClassFlag = FLAG_SHIP_CLASS_5;
 	switch (iShipRank)
 	{
 		case 0:  
-			iGlobalTemp = SHIP_CAREERLUGGER + rand(makeint(SHIP_SLOOP - SHIP_CAREERLUGGER));     					
+			iClassFlag = FLAG_SHIP_CLASS_5;					
 			iTotalTemp = CANNON_TYPE_CANNON_LBS6;
 			sTotalTemp = "blade_12";
 		break; 	
 		case 1:  
-			iGlobalTemp = SHIP_BRIGANTINE + rand(makeint(SHIP_SCHOONER_W - SHIP_BRIGANTINE));					
+			iClassFlag = FLAG_SHIP_CLASS_4;				
 			iTotalTemp = CANNON_TYPE_CANNON_LBS12;
 			sTotalTemp = "blade_14";
 		break; 		
 		case 2:  
-			iGlobalTemp = SHIP_GALEON_L + rand(makeint(SHIP_POLACRE - SHIP_GALEON_L));			
+			iClassFlag = FLAG_SHIP_CLASS_3;	
 			iTotalTemp = CANNON_TYPE_CANNON_LBS16;
 			sTotalTemp = "blade_13";
 		break; 
 		case 3: 
-			iGlobalTemp = SHIP_GALEON_L + rand(makeint(SHIP_POLACRE - SHIP_GALEON_L));			
+			iClassFlag = FLAG_SHIP_CLASS_3;		
 			iTotalTemp = CANNON_TYPE_CULVERINE_LBS18;
 			sTotalTemp = "blade_13";
 		break; 
 		case 4: 
-			iGlobalTemp = SHIP_GALEON_H + rand(makeint(SHIP_FRIGATE_H - SHIP_GALEON_H));         			
+			iClassFlag = FLAG_SHIP_CLASS_2;     			
 			iTotalTemp = CANNON_TYPE_CANNON_LBS24;
 			sTotalTemp = "blade_15";
 		break; 
 		case 5: 
-			iGlobalTemp = SHIP_GALEON_H + rand(makeint(SHIP_LINESHIP - SHIP_GALEON_H));  						
+			iClassFlag = FLAG_SHIP_CLASS_2;					
 			iTotalTemp = CANNON_TYPE_CANNON_LBS32;
 			sTotalTemp = "blade_19";
 		break;  				
 	}
+	
+	
+	iGlobalTemp = GetRandomShipType(iClassFlag, FLAG_SHIP_TYPE_WAR, FLAG_SHIP_NATION_ANY);
 }
 
 void SelectLevelTradeShipParameter()//Jason автолевеллинг на торговые корабли противника

--- a/Program/dialogs/english/Common_Shipyard.c
+++ b/Program/dialogs/english/Common_Shipyard.c
@@ -2769,27 +2769,33 @@ void SelectFindship_ShipType()
 	if (sti(pchar.rank) > 7 && sti(pchar.rank) <= 10) iRank = 4;
 	if (sti(pchar.rank) > 10 && sti(pchar.rank) <= 18) iRank = 5;
 	
+	int iClassFlag = FLAG_SHIP_CLASS_5;
+	int iTypesFlag = FLAG_SHIP_TYPE_MERCHANT;
 	switch (iRank)
 	{
 		case 0:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_SCHOONER + rand(makeint(SHIP_BARQUE - SHIP_SCHOONER));
+			iClassFlag = FLAG_SHIP_CLASS_5;
 		break; 		
 		case 1:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_BARKENTINE + rand(makeint(SHIP_SHNYAVA- SHIP_BARKENTINE));
+			iClassFlag = FLAG_SHIP_CLASS_4;
 		break;
 		case 2:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_FLEUT + rand(makeint(SHIP_CARAVEL - SHIP_FLEUT));
+			iClassFlag = FLAG_SHIP_CLASS_4;
 		break;
-		case 3:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_PINNACE + rand(makeint(SHIP_CARACCA - SHIP_PINNACE));	
+		case 3: 
+			iClassFlag = FLAG_SHIP_CLASS_3;
 		break;
 		case 4:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_SCHOONER_W + rand(makeint(SHIP_POLACRE - SHIP_SCHOONER_W));
+			iClassFlag = FLAG_SHIP_CLASS_3;
+			iTypesFlag = or(FLAG_SHIP_TYPE_MERCHANT, FLAG_SHIP_TYPE_WAR);
 		break;
-		case 5:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_NAVIO + rand(makeint(SHIP_FRIGATE_H - SHIP_NAVIO));
+		case 5: 
+			iClassFlag = FLAG_SHIP_CLASS_2;
+			iTypesFlag = or(FLAG_SHIP_TYPE_MERCHANT, FLAG_SHIP_TYPE_WAR);
 		break;
 	}
+	
+	pchar.GenQuest.Findship.Shipyarder.ShipType = GetRandomShipType(iClassFlag, iTypesFlag, FLAG_SHIP_NATION_ANY);
 }
 
 // проверка количества материалов для корабельного тюнинга

--- a/Program/dialogs/english/Population/Captain.c
+++ b/Program/dialogs/english/Population/Captain.c
@@ -137,12 +137,12 @@ void ProcessDialogEvent()
 
 int SelectCaptainShipType()
 {
-	int iType;
-	if (sti(pchar.rank) >= 19) iType = SHIP_FRIGATE_H;	
-	if (sti(pchar.rank) >= 13 && sti(pchar.rank) < 19) iType = SHIP_GALEON_H + drand(makeint(SHIP_FRIGATE_H - SHIP_GALEON_H));	
-	if (sti(pchar.rank) >= 8 && sti(pchar.rank) < 12) iType =  SHIP_CORVETTE + drand(makeint(SHIP_POLACRE -  SHIP_CORVETTE));
-	if (sti(pchar.rank) >= 5 && sti(pchar.rank) < 8) iType = SHIP_BRIGANTINE + drand(makeint(SHIP_GALEON_L - SHIP_BRIGANTINE));
-	if (sti(pchar.rank) < 5) iType = SHIP_CAREERLUGGER + drand(makeint(SHIP_SLOOP - SHIP_CAREERLUGGER));
+	int iClassFlag = FLAG_SHIP_CLASS_5;
+	if (sti(pchar.rank) >= 19) iClassFlag = FLAG_SHIP_CLASS_2;	
+	if (sti(pchar.rank) >= 13 && sti(pchar.rank) < 19) iClassFlag = FLAG_SHIP_CLASS_2;	
+	if (sti(pchar.rank) >= 8 && sti(pchar.rank) < 12) iClassFlag = FLAG_SHIP_CLASS_3;
+	if (sti(pchar.rank) >= 5 && sti(pchar.rank) < 8) iClassFlag = FLAG_SHIP_CLASS_4;
+	if (sti(pchar.rank) < 5) iType = iClassFlag = FLAG_SHIP_CLASS_5;
 	
-	return iType;
+	return GetRandomShipType(iClassFlag, FLAG_SHIP_TYPE_WAR, FLAG_SHIP_NATION_ANY);
 }

--- a/Program/dialogs/german/Common_Shipyard.c
+++ b/Program/dialogs/german/Common_Shipyard.c
@@ -2720,27 +2720,33 @@ void SelectFindship_ShipType()
 	if (sti(pchar.rank) > 7 && sti(pchar.rank) <= 10) iRank = 4;
 	if (sti(pchar.rank) > 10 && sti(pchar.rank) <= 18) iRank = 5;
 	
+	int iClassFlag = FLAG_SHIP_CLASS_5;
+	int iTypesFlag = FLAG_SHIP_TYPE_MERCHANT;
 	switch (iRank)
 	{
 		case 0:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_SCHOONER + rand(makeint(SHIP_BARQUE - SHIP_SCHOONER));
+			iClassFlag = FLAG_SHIP_CLASS_5;
 		break; 		
 		case 1:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_BARKENTINE + rand(makeint(SHIP_SHNYAVA- SHIP_BARKENTINE));
+			iClassFlag = FLAG_SHIP_CLASS_4;
 		break;
 		case 2:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_FLEUT + rand(makeint(SHIP_CARAVEL - SHIP_FLEUT));
+			iClassFlag = FLAG_SHIP_CLASS_4;
 		break;
-		case 3:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_PINNACE + rand(makeint(SHIP_CARACCA - SHIP_PINNACE));	
+		case 3: 
+			iClassFlag = FLAG_SHIP_CLASS_3;
 		break;
 		case 4:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_SCHOONER_W + rand(makeint(SHIP_POLACRE - SHIP_SCHOONER_W));
+			iClassFlag = FLAG_SHIP_CLASS_3;
+			iTypesFlag = or(FLAG_SHIP_TYPE_MERCHANT, FLAG_SHIP_TYPE_WAR);
 		break;
-		case 5:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_NAVIO + rand(makeint(SHIP_FRIGATE_H - SHIP_NAVIO));
+		case 5: 
+			iClassFlag = FLAG_SHIP_CLASS_2;
+			iTypesFlag = or(FLAG_SHIP_TYPE_MERCHANT, FLAG_SHIP_TYPE_WAR);
 		break;
 	}
+	
+	pchar.GenQuest.Findship.Shipyarder.ShipType = GetRandomShipType(iClassFlag, iTypesFlag, FLAG_SHIP_NATION_ANY);
 }
 
 // проверка количества материалов для корабельного тюнинга

--- a/Program/dialogs/german/Population/Captain.c
+++ b/Program/dialogs/german/Population/Captain.c
@@ -131,12 +131,12 @@ void ProcessDialogEvent()
 
 int SelectCaptainShipType()
 {
-	int iType;
-	if (sti(pchar.rank) >= 19) iType = SHIP_FRIGATE_H;	
-	if (sti(pchar.rank) >= 13 && sti(pchar.rank) < 19) iType = SHIP_GALEON_H + drand(makeint(SHIP_FRIGATE_H - SHIP_GALEON_H));	
-	if (sti(pchar.rank) >= 8 && sti(pchar.rank) < 12) iType =  SHIP_CORVETTE + drand(makeint(SHIP_POLACRE -  SHIP_CORVETTE));
-	if (sti(pchar.rank) >= 5 && sti(pchar.rank) < 8) iType = SHIP_BRIGANTINE + drand(makeint(SHIP_GALEON_L - SHIP_BRIGANTINE));
-	if (sti(pchar.rank) < 5) iType = SHIP_CAREERLUGGER + drand(makeint(SHIP_SLOOP - SHIP_CAREERLUGGER));
+	int iClassFlag = FLAG_SHIP_CLASS_5;
+	if (sti(pchar.rank) >= 19) iClassFlag = FLAG_SHIP_CLASS_2;	
+	if (sti(pchar.rank) >= 13 && sti(pchar.rank) < 19) iClassFlag = FLAG_SHIP_CLASS_2;	
+	if (sti(pchar.rank) >= 8 && sti(pchar.rank) < 12) iClassFlag = FLAG_SHIP_CLASS_3;
+	if (sti(pchar.rank) >= 5 && sti(pchar.rank) < 8) iClassFlag = FLAG_SHIP_CLASS_4;
+	if (sti(pchar.rank) < 5) iType = iClassFlag = FLAG_SHIP_CLASS_5;
 	
-	return iType;
+	return GetRandomShipType(iClassFlag, FLAG_SHIP_TYPE_WAR, FLAG_SHIP_NATION_ANY);
 }

--- a/Program/dialogs/russian/Common_Shipyard.c
+++ b/Program/dialogs/russian/Common_Shipyard.c
@@ -2774,27 +2774,33 @@ void SelectFindship_ShipType()
 	if (sti(pchar.rank) > 7 && sti(pchar.rank) <= 10) iRank = 4;
 	if (sti(pchar.rank) > 10 && sti(pchar.rank) <= 18) iRank = 5;
 	
+	int iClassFlag = FLAG_SHIP_CLASS_5;
+	int iTypesFlag = FLAG_SHIP_TYPE_MERCHANT;
 	switch (iRank)
 	{
 		case 0:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_SCHOONER + rand(makeint(SHIP_BARQUE - SHIP_SCHOONER));
+			iClassFlag = FLAG_SHIP_CLASS_5;
 		break; 		
 		case 1:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_BARKENTINE + rand(makeint(SHIP_SHNYAVA- SHIP_BARKENTINE));
+			iClassFlag = FLAG_SHIP_CLASS_4;
 		break;
 		case 2:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_FLEUT + rand(makeint(SHIP_CARAVEL - SHIP_FLEUT));
+			iClassFlag = FLAG_SHIP_CLASS_4;
 		break;
-		case 3:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_PINNACE + rand(makeint(SHIP_CARACCA - SHIP_PINNACE));	
+		case 3: 
+			iClassFlag = FLAG_SHIP_CLASS_3;
 		break;
 		case 4:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_SCHOONER_W + rand(makeint(SHIP_POLACRE - SHIP_SCHOONER_W));
+			iClassFlag = FLAG_SHIP_CLASS_3;
+			iTypesFlag = or(FLAG_SHIP_TYPE_MERCHANT, FLAG_SHIP_TYPE_WAR);
 		break;
-		case 5:  
-			pchar.GenQuest.Findship.Shipyarder.ShipType = SHIP_NAVIO + rand(makeint(SHIP_FRIGATE_H - SHIP_NAVIO));
+		case 5: 
+			iClassFlag = FLAG_SHIP_CLASS_2;
+			iTypesFlag = or(FLAG_SHIP_TYPE_MERCHANT, FLAG_SHIP_TYPE_WAR);
 		break;
 	}
+	
+	pchar.GenQuest.Findship.Shipyarder.ShipType = GetRandomShipType(iClassFlag, iTypesFlag, FLAG_SHIP_NATION_ANY);
 }
 
 // проверка количества материалов для корабельного тюнинга

--- a/Program/dialogs/russian/Population/Captain.c
+++ b/Program/dialogs/russian/Population/Captain.c
@@ -137,12 +137,12 @@ void ProcessDialogEvent()
 
 int SelectCaptainShipType()
 {
-	int iType;
-	if (sti(pchar.rank) >= 19) iType = SHIP_FRIGATE_H;	
-	if (sti(pchar.rank) >= 13 && sti(pchar.rank) < 19) iType = SHIP_GALEON_H + drand(makeint(SHIP_FRIGATE_H - SHIP_GALEON_H));	
-	if (sti(pchar.rank) >= 8 && sti(pchar.rank) < 12) iType =  SHIP_CORVETTE + drand(makeint(SHIP_POLACRE -  SHIP_CORVETTE));
-	if (sti(pchar.rank) >= 5 && sti(pchar.rank) < 8) iType = SHIP_BRIGANTINE + drand(makeint(SHIP_GALEON_L - SHIP_BRIGANTINE));
-	if (sti(pchar.rank) < 5) iType = SHIP_CAREERLUGGER + drand(makeint(SHIP_SLOOP - SHIP_CAREERLUGGER));
+	int iClassFlag = FLAG_SHIP_CLASS_5;
+	if (sti(pchar.rank) >= 19) iClassFlag = FLAG_SHIP_CLASS_2;	
+	if (sti(pchar.rank) >= 13 && sti(pchar.rank) < 19) iClassFlag = FLAG_SHIP_CLASS_2;	
+	if (sti(pchar.rank) >= 8 && sti(pchar.rank) < 12) iClassFlag = FLAG_SHIP_CLASS_3;
+	if (sti(pchar.rank) >= 5 && sti(pchar.rank) < 8) iClassFlag = FLAG_SHIP_CLASS_4;
+	if (sti(pchar.rank) < 5) iType = iClassFlag = FLAG_SHIP_CLASS_5;
 	
-	return iType;
+	return GetRandomShipType(iClassFlag, FLAG_SHIP_TYPE_WAR, FLAG_SHIP_NATION_ANY);
 }

--- a/Program/interface/utilite.c
+++ b/Program/interface/utilite.c
@@ -536,7 +536,7 @@ void FillShipList(string strAccess, ref chref)
 	int n;
 	string sShip;
 
-	for(n= 0; n< SHIP_TYPES_QUANTITY; n++)
+	for(n= 0; n< GetArraySize(&ShipsTypes); n++)
 	{
 		if(CheckAttribute(ShipsTypes[n], "name"))
 		sShip = ShipsTypes[n].name;

--- a/Program/migrations/0054_ship_generator_flags.c
+++ b/Program/migrations/0054_ship_generator_flags.c
@@ -1,0 +1,42 @@
+void ApplyMigration(ref migrationState) {
+	
+	ref refShip;
+	makeref(refShip,ShipsTypes[SHIP_BOAT]);
+	refShip.ShipHolder = true;
+	
+	makeref(refShip,ShipsTypes[SHIP_LSHIP_FRA]);
+	refShip.CanEncounter = false;
+	
+	makeref(refShip,ShipsTypes[SHIP_LSHIP_HOL]);
+	refShip.CanEncounter = false;
+	
+	makeref(refShip,ShipsTypes[SHIP_LSHIP_SPA]);
+	refShip.CanEncounter = false;
+	
+	makeref(refShip,ShipsTypes[SHIP_LSHIP_ENG]);
+	refShip.CanEncounter = false;
+	
+	makeref(refShip,ShipsTypes[SHIP_QUEST4]);
+	refShip.ShipHolder  = true;
+	
+	makeref(refShip,ShipsTypes[SHIP_QUEST5]);
+	refship.QuestShip	= true;
+	refship.ShipHolder	= true;
+	
+	makeref(refShip,ShipsTypes[SHIP_QUEST6]);
+	refship.ShipHolder	= true;
+	
+	makeref(refShip,ShipsTypes[SHIP_QUEST7]);
+	refship.QuestShip	= true;
+	refship.ShipHolder	= true;
+	
+	makeref(refShip,ShipsTypes[SHIP_QUEST8]);
+	refship.QuestShip	= true;
+	refship.ShipHolder	= true;
+	
+	makeref(refShip,ShipsTypes[SHIP_FORT]);
+	refShip.ShipHolder  = true;
+	
+	makeref(refShip,ShipsTypes[SHIP_FORT + 1]);
+	refShip.ShipHolder  = true;
+}

--- a/Program/scripts/GenQuests.c
+++ b/Program/scripts/GenQuests.c
@@ -7437,39 +7437,45 @@ void FrahtHunterOnSea()//охотники в акватории порта пр�
 		if(makeint(pchar.rank) >= 8 && makeint(pchar.rank) < 12) { iShipRank = 2; }	
 		if(makeint(pchar.rank) >= 5 && makeint(pchar.rank) < 8) { iShipRank = 1; }	
 		if(makeint(pchar.rank) < 5) { iShipRank = 0; }
+		
+		
+		int iClassFlag = FLAG_SHIP_CLASS_5;
 		switch (iShipRank)
 		{
 			case 0:  
-				iShipType = SHIP_LUGGER + rand(makeint(SHIP_SLOOP - SHIP_LUGGER));     					
-				iCannonType = CANNON_TYPE_CANNON_LBS6;
-				sBlade = "blade_03";
+				iClassFlag = FLAG_SHIP_CLASS_5;					
+				iTotalTemp = CANNON_TYPE_CANNON_LBS6;
+				sTotalTemp = "blade_03";
 			break; 	
 			case 1:  
-				iShipType = SHIP_SLOOP + rand(makeint(SHIP_BRIG - SHIP_SLOOP));					
-				iCannonType = CANNON_TYPE_CANNON_LBS12;
-				sBlade = "blade_05";
+				iClassFlag = FLAG_SHIP_CLASS_4;				
+				iTotalTemp = CANNON_TYPE_CANNON_LBS12;
+				sTotalTemp = "blade_05";
 			break; 		
 			case 2:  
-				iShipType = SHIP_BRIG + rand(makeint(SHIP_GALEON_L - SHIP_BRIG));			
-				iCannonType = CANNON_TYPE_CANNON_LBS16;
-				sBlade = "blade_06";
-			break; 		
+				iClassFlag = FLAG_SHIP_CLASS_3;	
+				iTotalTemp = CANNON_TYPE_CANNON_LBS16;
+				sTotalTemp = "blade_06";
+			break; 
 			case 3: 
-				iShipType = SHIP_GALEON_L + rand(makeint(SHIP_XebekVML - SHIP_GALEON_L));				
-				iCannonType = CANNON_TYPE_CULVERINE_LBS18;
-				sBlade = "blade_10";
+				iClassFlag = FLAG_SHIP_CLASS_3;		
+				iTotalTemp = CANNON_TYPE_CULVERINE_LBS18;
+				sTotalTemp = "blade_10";
 			break; 
 			case 4: 
-				iShipType = SHIP_CORVETTE + rand(makeint(SHIP_POLACRE - SHIP_CORVETTE));         			
-				iCannonType = CANNON_TYPE_CANNON_LBS20;
-				sBlade = "blade_13";
+				iClassFlag = FLAG_SHIP_CLASS_2;     			
+				iTotalTemp = CANNON_TYPE_CANNON_LBS20;
+				sTotalTemp = "blade_13";
 			break; 
 			case 5: 
-				iShipType = SHIP_GALEON_H + rand(makeint(SHIP_FRIGATE_H - SHIP_GALEON_H));  						
-				iCannonType = CANNON_TYPE_CANNON_LBS24;
-				sBlade = "blade_19";
+				iClassFlag = FLAG_SHIP_CLASS_2;					
+				iTotalTemp = CANNON_TYPE_CANNON_LBS24;
+				sTotalTemp = "blade_19";
 			break;  				
 		}
+		
+		
+		iShipType = GetRandomShipType(iClassFlag, FLAG_SHIP_TYPE_WAR, FLAG_SHIP_NATION_ANY);
 		sld = GetCharacter(NPC_GenerateCharacter("FrahtAttack_"+i, "citiz_"+(rand(9)+41), "man", "man", iRank, iNation, 30, true, "quest"));//создание кэпа
 		FantomMakeSmallSailor(sld, iShipType, "", iCannonType, 30+rand(15), 20+rand(10), 20+rand(15), 20+rand(15), 20+rand(15));
 		FantomMakeCoolFighter(sld, iRank, 30, 30, sBlade, "pistol1", "bullet", 30);

--- a/Program/scripts/ShipsUtilites.c
+++ b/Program/scripts/ShipsUtilites.c
@@ -992,174 +992,74 @@ void SetShipyardStore(ref NPChar)
     
     if (bBettaTestMode)
     {
-        for (i = 1; i <= SHIP_TYPES_QUANTITY; i++)
+        for (i = 1; i <= GetArraySize(&ShipsTypes); i++)
         {
+			ref refShip;
+			makeref(refShip,ShipsTypes[i]);
+			if (!CheckAttribute(refShip, "Class"))
+			{
+				continue;
+			}
             attrName = "ship" + i;
 			FillShipParamShipyard(NPChar, GenerateStoreShipExt(i-1, NPChar), attrName);
         }        
         return;
     }
+	int iNationFlag = GetNationFlag(sti(NPChar.nation));
 	
-    if(sti(NPChar.nation) == ENGLAND || sti(NPChar.nation) == FRANCE || sti(NPChar.nation) == SPAIN || sti(NPChar.nation) == HOLLAND)
+	FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_TARTANE, NPChar), "ship1");
+	
+	
+	iTest_ship = rand(2);
+	if (iTest_ship != 0) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_6+FLAG_SHIP_CLASS_5, FLAG_SHIP_TYPE_ANY, iNationFlag), NPChar), "ship2");
+	iTest_ship = rand(2);
+	if (iTest_ship != 0) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_5, FLAG_SHIP_TYPE_ANY, iNationFlag), NPChar), "ship3");
+	iTest_ship = rand(3);
+	if (iTest_ship != 0) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_5, FLAG_SHIP_TYPE_ANY, iNationFlag), NPChar), "ship4");
+	
+	if (sti(PChar.rank) > 1)
 	{
-		FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_TARTANE, NPChar), "ship1");
-		
-		iTest_ship = rand(2);
-		if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_WAR_TARTANE, NPChar), "ship2");
-		if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_LUGGER, NPChar), "ship2");
-		
-		iTest_ship = rand(2);
-		if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_LUGGER, NPChar), "ship3");
-		if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SLOOP, NPChar), "ship3");
-		
-		iTest_ship = rand(3);
-		if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SLOOP, NPChar), "ship4");
-		if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_LUGGER, NPChar), "ship4");
-		if (iTest_ship == 3) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_CAREERLUGGER, NPChar), "ship4");
-		
-		if (sti(PChar.rank) > 1)
-		{
-			iTest_ship = rand(4);
-			if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SCHOONER, NPChar), "ship5");
-			if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BARQUE, NPChar), "ship5");
-	
-			iTest_ship = rand(4);
-			if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SCHOONER, NPChar), "ship6");
-			if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BARQUE, NPChar), "ship6");
-		}
-		
-		if (sti(PChar.rank) > 3)
-		{
-			iTest_ship = rand(6);
-			if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_CARAVEL, NPChar), "ship8");
-			if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SHNYAVA, NPChar), "ship8");
-	
-			iTest_ship = rand(6);
-			if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_FLEUT, NPChar), "ship9");
-			if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_CARAVEL, NPChar), "ship9");
-	
-			iTest_ship = rand(6);
-			if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_FLEUT, NPChar), "ship10");
-			if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_CARAVEL, NPChar), "ship10");
-			if (iTest_ship == 3) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BARKENTINE, NPChar), "ship10");		
-			if (iTest_ship == 4) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SHNYAVA, NPChar), "ship10");		
-		}
-		
-		if (sti(PChar.rank) > 5)
-		{
-			iTest_ship = rand(8);
-			if (iTest_ship == 1 && sti(NPChar.nation) == ENGLAND) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BRIG, NPChar), "ship11");
-			if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_FLEUT, NPChar), "ship11");
-			if (iTest_ship == 3) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BARKENTINE, NPChar), "ship11");
-			if (iTest_ship == 4 && sti(NPChar.nation) == FRANCE) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SCHOONER_W, NPChar), "ship11");
-			if (iTest_ship == 5 && sti(NPChar.nation) == HOLLAND) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SCHOONER_W, NPChar), "ship11");
-	
-			iTest_ship = rand(8);
-			if (iTest_ship == 1 && sti(NPChar.nation) == ENGLAND) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BRIG, NPChar), "ship12");
-			if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_GALEON_L, NPChar), "ship12");
-			if (iTest_ship == 3 && sti(NPChar.nation) == SPAIN) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BRIGANTINE, NPChar), "ship12");
-			if (iTest_ship == 4 && sti(NPChar.nation) == FRANCE) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SCHOONER_W, NPChar), "ship12");
-			if (iTest_ship == 5 && sti(NPChar.nation) == HOLLAND) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SCHOONER_W, NPChar), "ship12");
-	
-			iTest_ship = rand(8);
-			if (iTest_ship == 1 && sti(NPChar.nation) == ENGLAND) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BRIG, NPChar), "ship13");
-			if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_GALEON_L, NPChar), "ship13");
-			if (iTest_ship == 3 && sti(NPChar.nation) == SPAIN) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BRIGANTINE, NPChar), "ship13");
-			if (iTest_ship == 4 && sti(NPChar.nation) == FRANCE) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SCHOONER_W, NPChar), "ship13");
-			if (iTest_ship == 5 && sti(NPChar.nation) == HOLLAND) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SCHOONER_W, NPChar), "ship13");
-		}
-		
-		if (sti(PChar.rank) > 8)
-		{
-			iTest_ship = rand(30);
-			if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_GALEON_L, NPChar), "ship14");
-			if (iTest_ship == 2 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_CORVETTE, NPChar), "ship14");
-			if (iTest_ship == 3 && sti(NPChar.nation) == FRANCE) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_CORVETTE, NPChar), "ship14");
-			if (iTest_ship == 4) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_CARACCA, NPChar), "ship14");
-			
-			if (iTest_ship == 5 && sti(NPChar.nation) == SPAIN) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_XebekVML, NPChar), "ship14");
-			if (iTest_ship == 6 && sti(NPChar.nation) == HOLLAND) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_XebekVML, NPChar), "ship14");
-			
-			if (iTest_ship == 7 && sti(NPChar.nation) == SPAIN) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_POLACRE, NPChar), "ship14");
-			if (iTest_ship == 6 && sti(NPChar.nation) == FRANCE) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_POLACRE, NPChar), "ship14");
-	
-			iTest_ship = rand(40);
-			if (iTest_ship == 1 && sti(NPChar.nation) == SPAIN) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_GALEON_H, NPChar), "ship15");
-			if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_PINNACE, NPChar), "ship15");
-			if (iTest_ship == 3 && sti(NPChar.nation) == ENGLAND) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_CORVETTE, NPChar), "ship15");
-			if (iTest_ship == 4 && sti(NPChar.nation) == FRANCE) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_CORVETTE, NPChar), "ship15");
-			
-			if (iTest_ship == 5 && sti(NPChar.nation) == SPAIN) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_XebekVML, NPChar), "ship15");
-			if (iTest_ship == 6 && sti(NPChar.nation) == HOLLAND) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_XebekVML, NPChar), "ship15");
-			
-			if (iTest_ship == 7 && sti(NPChar.nation) == SPAIN) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_POLACRE, NPChar), "ship15");
-			if (iTest_ship == 6 && sti(NPChar.nation) == FRANCE) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_POLACRE, NPChar), "ship15");
-		}
-		if (sti(PChar.rank) > 12)
-		{	
-			iTest_ship = rand(30);
-			if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_PINNACE, NPChar), "ship16");
-			if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_NAVIO, NPChar), "ship16");
-			if (iTest_ship == 3) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_EASTINDIAMAN, NPChar), "ship16");
-			if (iTest_ship == 4 && sti(NPChar.nation) == SPAIN) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_GALEON_H, NPChar), "ship16");
-			if (iTest_ship == 5 && sti(NPChar.nation) == ENGLAND) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_FRIGATE, NPChar), "ship16");
-			if (iTest_ship == 6 && sti(NPChar.nation) == FRANCE) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_FRIGATE, NPChar), "ship16");
-			if (iTest_ship == 7 && sti(NPChar.nation) == FRANCE) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_CORVETTE, NPChar), "ship16");
-			if (iTest_ship == 8) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_FRIGATE_H, NPChar), "ship16");
-		}  
+		iTest_ship = rand(4);
+		if (iTest_ship <= 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_4, FLAG_SHIP_TYPE_MERCHANT, iNationFlag), NPChar), "ship5");
+		iTest_ship = rand(4);
+		if (iTest_ship <= 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_4, FLAG_SHIP_TYPE_MERCHANT, iNationFlag), NPChar), "ship6");
 	}
-	else
+	
+	if (sti(PChar.rank) > 3)
 	{
-		iTest_ship = rand(2);
-		if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_WAR_TARTANE, NPChar), "ship2");
-		if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_LUGGER, NPChar), "ship2");
-		
-		iTest_ship = rand(2);
-		if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_LUGGER, NPChar), "ship3");
-		if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SLOOP, NPChar), "ship3");
-		
-		iTest_ship = rand(3);
-		if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SLOOP, NPChar), "ship4");
-		if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_LUGGER, NPChar), "ship4");
-		
-		if (sti(PChar.rank) > 5)
-		{
-			iTest_ship = rand(8);
-			if (iTest_ship == 1 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BRIG, NPChar), "ship11");
-			if (iTest_ship == 2 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SCHOONER_W, NPChar), "ship11");
+		iTest_ship = rand(6);
+		if (iTest_ship <= 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_3, FLAG_SHIP_TYPE_MERCHANT, iNationFlag), NPChar), "ship8");
+		iTest_ship = rand(6);
+		if (iTest_ship <= 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_3, FLAG_SHIP_TYPE_MERCHANT, iNationFlag), NPChar), "ship9");
+		iTest_ship = rand(6);
+		if (iTest_ship <= 3) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_3, FLAG_SHIP_TYPE_MERCHANT, iNationFlag), NPChar), "ship10");
+	}
 	
-			iTest_ship = rand(8);
-			if (iTest_ship == 1 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BRIG, NPChar), "ship12");
-			if (iTest_ship == 2 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_GALEON_L, NPChar), "ship12");
-			if (iTest_ship == 3 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BRIGANTINE, NPChar), "ship12");
-			if (iTest_ship == 4 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SCHOONER_W, NPChar), "ship12");
+	if (sti(PChar.rank) > 5)
+	{
+		iTest_ship = rand(8);
+		if (iTest_ship <= 4) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_4, FLAG_SHIP_TYPE_ANY, iNationFlag), NPChar), "ship11");
+		iTest_ship = rand(6);
+		if (iTest_ship <= 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_4, FLAG_SHIP_TYPE_ANY, iNationFlag), NPChar), "ship12");
+		iTest_ship = rand(6);
+		if (iTest_ship <= 3) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_3, FLAG_SHIP_TYPE_MERCHANT, iNationFlag), NPChar), "ship13");
+	}
 	
-			iTest_ship = rand(8);
-			if (iTest_ship == 1 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BRIG, NPChar), "ship13");
-			if (iTest_ship == 2 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_GALEON_L, NPChar), "ship13");
-			if (iTest_ship == 3 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_BRIGANTINE, NPChar), "ship13");
-			if (iTest_ship == 4 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_SCHOONER_W, NPChar), "ship13");
-		}
-		
-		if (sti(PChar.rank) > 8)
-		{
-			iTest_ship = rand(30);
-			if (iTest_ship == 1 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_GALEON_L, NPChar), "ship14");
-			if (iTest_ship == 2 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_CORVETTE, NPChar), "ship14");
-			
-			iTest_ship = rand(40);
-			if (iTest_ship == 1 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_GALEON_H, NPChar), "ship15");			
-			if (iTest_ship == 2 ) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_CORVETTE, NPChar), "ship15");
-		}
-		if (sti(PChar.rank) > 12)
-		{	
-			iTest_ship = rand(30);
-			if (iTest_ship == 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_NAVIO, NPChar), "ship16");
-			if (iTest_ship == 2) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_EASTINDIAMAN, NPChar), "ship16");
-			if (iTest_ship == 3) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_GALEON_H, NPChar), "ship16");
-			if (iTest_ship == 4) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_FRIGATE, NPChar), "ship16");
-			if (iTest_ship == 5) FillShipParamShipyard(NPChar, GenerateStoreShipExt(SHIP_FRIGATE_H, NPChar), "ship16");		
-		}    
+	if (sti(PChar.rank) > 8)
+	{
+		iTest_ship = rand(30);
+		if (iTest_ship <= 5) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_3, FLAG_SHIP_TYPE_ANY, iNationFlag), NPChar), "ship14");
+		iTest_ship = rand(40);
+		if (iTest_ship <= 6) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_3, FLAG_SHIP_TYPE_ANY, iNationFlag), NPChar), "ship15");
+		iTest_ship = rand(30);
+		if (iTest_ship <= 1) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_2, FLAG_SHIP_TYPE_ANY, iNationFlag), NPChar), "ship16");
+	}
+	
+	if (sti(PChar.rank) > 12)
+	{
+		iTest_ship = rand(30);
+		if (iTest_ship <= 7) FillShipParamShipyard(NPChar, GenerateStoreShipExt(GetRandomShipType(FLAG_SHIP_CLASS_2, FLAG_SHIP_TYPE_ANY, iNationFlag), NPChar), "ship17");
+
 	}
 }
 

--- a/Program/scripts/Siege.c
+++ b/Program/scripts/Siege.c
@@ -279,27 +279,30 @@ int SetSiegeShip(ref rChar)
 
     if (sti(aData.imanofwars) > 0)
     {
+		int iNationLineshipType = SHIP_LINESHIP;
 		switch (Nation)
 		{	
-			case PIRATE   :	SiegeShips = SHIP_LINESHIP; 													 break; 
-			case ENGLAND  : SiegeShips = RandFromThreeDight(SHIP_LINESHIP, SHIP_LSHIP_ENG,  SHIP_LINESHIP);  break; 
-			case FRANCE	  : SiegeShips = RandFromThreeDight(SHIP_LINESHIP, SHIP_LSHIP_FRA,  SHIP_LINESHIP);  break; 					
-			case SPAIN	  : SiegeShips = RandFromThreeDight(SHIP_LINESHIP, SHIP_LSHIP_SPA,  SHIP_LINESHIP);  break; 					
-			case HOLLAND  : SiegeShips = RandFromThreeDight(SHIP_LINESHIP, SHIP_LSHIP_HOL,  SHIP_LINESHIP);  break; 
+			case PIRATE   :	iNationLineshipType = SHIP_LINESHIP;   break; 
+			case ENGLAND  : iNationLineshipType = SHIP_LSHIP_ENG;  break; 
+			case FRANCE	  : iNationLineshipType = SHIP_LSHIP_FRA;  break; 					
+			case SPAIN	  : iNationLineshipType = SHIP_LSHIP_SPA;  break; 					
+			case HOLLAND  : iNationLineshipType = SHIP_LSHIP_HOL;  break; 
+		}
+		
+		if (rand(2) == 0)
+		{
+			SiegeShips = iNationLineshipType;
+		}
+		else
+		{
+			SiegeShips = GetRandomShipType(FLAG_SHIP_CLASS_1, FLAG_SHIP_TYPE_WAR, GetNationFlag(Nation));
 		}
         aData.imanofwars = sti(aData.imanofwars) - 1;
         rez = SiegeShips;
     }
     else
     {
-		switch (Nation)
-		{	
-			case PIRATE   :	SiegeShips = RandFromThreeDight(SHIP_CORVETTE, SHIP_GALEON_H, SHIP_FRIGATE); 	break; 
-			case ENGLAND  : SiegeShips = RandFromThreeDight(SHIP_CORVETTE, SHIP_FRIGATE,  SHIP_FRIGATE_H); 	break; 
-			case FRANCE	  : SiegeShips = RandFromThreeDight(SHIP_CORVETTE, SHIP_FRIGATE,  SHIP_FRIGATE_H); 	break; 					
-			case SPAIN	  : SiegeShips = RandFromThreeDight(SHIP_POLACRE,  SHIP_GALEON_H, SHIP_FRIGATE_H);  break; 					
-			case HOLLAND  : SiegeShips = RandFromThreeDight(SHIP_XebekVML, SHIP_FRIGATE,  SHIP_FRIGATE_H);  break; 
-		}		
+		SiegeShips = GetRandomShipType(FLAG_SHIP_CLASS_2 + FLAG_SHIP_CLASS_3, FLAG_SHIP_TYPE_WAR, GetNationFlag(Nation));
         rez = SiegeShips;
     }
 

--- a/Program/sea_ai/AIFantom.c
+++ b/Program/sea_ai/AIFantom.c
@@ -1315,76 +1315,73 @@ void SetShipToFantom(ref _chr, string _type, bool _setgoods)
 	int ShipType;
 	int Nation = sti(_chr.nation);
 	int Rank = sti(pchar.rank);
+	int iClassFlag = FLAG_SHIP_CLASS_5;
+	int iTypesFlag = FLAG_SHIP_TYPE_MERCHANT;
+	int iNationsFlag = GetNationFlag(Nation);
 	switch (_type)
 	{
-		case "trade":		
+		case "trade":	
+			iTypesFlag = FLAG_SHIP_TYPE_MERCHANT;
 			if (Rank < 11)
 			{
-				ShipType = RandFromFiveDight(SHIP_BARQUE, SHIP_SCHOONER, SHIP_BARKENTINE, SHIP_SHNYAVA, SHIP_FLEUT);
+				iClassFlag = FLAG_SHIP_CLASS_4;
 			}
 			if (Rank >= 11 && Rank <= 20)
 			{
-				ShipType = RandFromThreeDight(SHIP_CARAVEL, SHIP_PINNACE, SHIP_CARACCA);
+				iClassFlag = FLAG_SHIP_CLASS_3;
 			}
             if (Rank > 20 && Rank <= 30)
             {
-                ShipType = RandFromFiveDight(SHIP_CARACCA, SHIP_PINNACE, SHIP_FLEUT);
+				iClassFlag = FLAG_SHIP_CLASS_3;
             }
 			if (Rank > 30)
 			{
-				ShipType = RandFromThreeDight(SHIP_CARACCA, SHIP_NAVIO, SHIP_EASTINDIAMAN);
+				iClassFlag = FLAG_SHIP_CLASS_2;
 			}
 		break;
 		case "pirate":
+			iTypesFlag = FLAG_SHIP_TYPE_MERCHANT + FLAG_SHIP_TYPE_WAR;
 			if (Rank < 4)
 			{
-				ShipType = SHIP_LUGGER;
+				iClassFlag = FLAG_SHIP_CLASS_5;
 			}			
 			if (Rank >= 4 && Rank < 11)
 			{
-				ShipType = RandFromThreeDight(SHIP_SLOOP, SHIP_BRIGANTINE, SHIP_BRIG);
+				iClassFlag = FLAG_SHIP_CLASS_4;
 			}
 			if (Rank >= 11 && Rank <= 20)
 			{
-				ShipType = RandFromThreeDight(SHIP_SCHOONER_W, SHIP_GALEON_L, SHIP_CORVETTE);
+				iClassFlag = FLAG_SHIP_CLASS_3;
 			}
             if (Rank > 20 && Rank <= 30)
             {
-                ShipType = RandFromFiveDight(SHIP_SCHOONER_W, SHIP_CORVETTE, SHIP_POLACRE);
+                iClassFlag = FLAG_SHIP_CLASS_3;
             }
 			if (Rank > 30)
 			{
-				ShipType = RandFromThreeDight(SHIP_CORVETTE, SHIP_GALEON_H, SHIP_LINESHIP);
+				iClassFlag = FLAG_SHIP_CLASS_2;
 			}
 		break;
 
 		case "war":
+			iTypesFlag = FLAG_SHIP_TYPE_WAR;
 			if (Rank < 11)
 			{
-				ShipType = RandFromThreeDight(SHIP_CAREERLUGGER, SHIP_LUGGER, SHIP_SLOOP);
+				iClassFlag = FLAG_SHIP_CLASS_4;
 			}
 			if (Rank >= 11 && Rank <= 30)
 			{
-				switch (Nation)
-				{
-					case ENGLAND  : ShipType = RandFromThreeDight(SHIP_BRIG, SHIP_GALEON_L, SHIP_CORVETTE); break; 
-					case FRANCE	  : ShipType = RandFromThreeDight(SHIP_SCHOONER_W, SHIP_GALEON_L, SHIP_CORVETTE); break; 					
-					case SPAIN	  : ShipType = RandFromThreeDight(SHIP_BRIGANTINE, SHIP_GALEON_L, SHIP_XebekVML); break; 					
-					case HOLLAND  : ShipType = RandFromFiveDight(SHIP_SCHOONER_W, SHIP_GALEON_L, SHIP_CORVETTE, SHIP_POLACRE, SHIP_SCHOONER_W); break; 
-				}						
+				iClassFlag = FLAG_SHIP_CLASS_3;					
 			}
 			if (Rank > 30)
 			{
-				switch (Nation)
-				{
-					case ENGLAND  : ShipType = RandFromThreeDight(SHIP_FRIGATE, SHIP_FRIGATE_H, SHIP_LINESHIP); break; 
-					case FRANCE	  : ShipType = RandFromThreeDight(SHIP_FRIGATE, SHIP_FRIGATE_H, SHIP_LINESHIP); break; 					
-					case SPAIN	  : ShipType = RandFromFiveDight(SHIP_POLACRE, SHIP_GALEON_H, SHIP_FRIGATE_H, SHIP_GALEON_H, SHIP_LINESHIP); break; 					
-					case HOLLAND  : ShipType = RandFromThreeDight(SHIP_FRIGATE, SHIP_FRIGATE_H, SHIP_LINESHIP); break; 
-				}						
+				iClassFlag = FLAG_SHIP_CLASS_2;					
 			}
 		break;
 	}
+	
+	ShipType = GetRandomShipType(iClassFlag, iTypesFlag, iNationsFlag);
+	
 	_chr.Ship.Type = GenerateShipExt(ShipType, true, _chr);
 	SetRandomNameToShip(_chr);
     SetBaseShipData(_chr);

--- a/Program/sea_ai/AIShip.c
+++ b/Program/sea_ai/AIShip.c
@@ -784,7 +784,7 @@ void Ship_Add2Sea(int iCharacterIndex, bool bFromCoast, string sFantomType, bool
 		if (MOD_BETTATESTMODE == "On") Log_Info("Ship_Add2Sea ERROR : SHIP " + iShipType + ", have no name!   NPCid = "+ rCharacter.id);
 		return;
 	}
-	if (iRealShip >= SHIP_TYPES_QUANTITY)
+	if (iRealShip >= GetArraySize(&ShipsTypes))
 	{
 		Trace("Character.id = " + rCharacter.id + ", have invalid ship type = " + iShipType + ", and try load to sea");
 		return;

--- a/Program/seadogs.c
+++ b/Program/seadogs.c
@@ -40,6 +40,8 @@
 #include "controls\controls_func.c" // belamour процессирование контролок 
 #include "migrations.c"
 #include "achievements.c"
+#include "ships/ships_generator.c"
+
 
 extern void InitBaseCannons();
 extern void InitCharacters();

--- a/Program/ships/ships_generator.c
+++ b/Program/ships/ships_generator.c
@@ -1,0 +1,203 @@
+
+
+
+#define FLAG_SHIP_TYPE_WAR 1
+#define FLAG_SHIP_TYPE_MERCHANT 2
+//#define FLAG_SHIP_TYPE_SCOUT 4
+#define FLAG_SHIP_TYPE_ANY 3
+
+#define SHIP_TYPE_COUNT 2
+int gShipTypeFlags[SHIP_TYPE_COUNT] = {1, 2}
+string gTypeFields[SHIP_TYPE_COUNT] = {"War", "Merchant"};
+
+#define FLAG_SHIP_CLASS_1  1
+#define FLAG_SHIP_CLASS_2  2
+#define FLAG_SHIP_CLASS_3  4
+#define FLAG_SHIP_CLASS_4  8
+#define FLAG_SHIP_CLASS_5 16
+#define FLAG_SHIP_CLASS_6 32
+
+int gShipClassFlags[7] = {0, 1, 2, 4, 8, 16, 32}
+
+#define FLAG_SHIP_NATION_ENGLAND   1
+#define FLAG_SHIP_NATION_FRANCE    2
+#define FLAG_SHIP_NATION_SPAIN     4
+#define FLAG_SHIP_NATION_HOLLAND   8
+#define FLAG_SHIP_NATION_PIRATE   16
+#define FLAG_SHIP_NATION_ANY      31
+
+
+
+
+
+string gNationFields[MAX_NATIONS] = {"england", "france", "spain", "holland", "pirate"};
+int gShipNationFlags[MAX_NATIONS] = {1, 2, 4, 8, 16}
+
+int GetClassFlag(int class) {
+	if (class > 6)
+		return FLAG_SHIP_CLASS_6;
+	if (class < 1)
+		return FLAG_SHIP_CLASS_1;
+	return gShipClassFlags[class];
+	
+}
+
+int GetNationFlag(int nation) {
+	if (nation >= MAX_NATIONS)
+		nation = MAX_NATIONS - 1;
+	if (nation < 0)
+		nation = 0;
+	return gShipNationFlags[nation];
+	
+}
+
+// Usage: GetRandomShipType(FLAG_SHIP_CLASS_2 + FLAG_SHIP_CLASS_3 + FLAG_SHIP_CLASS_4, FLAG_SHIP_TYPE_WAR + FLAG_SHIP_TYPE_MERCHANT, FLAG_SHIP_NATION_ENGLAND + FLAG_SHIP_NATION_PIRATE)
+// Gives random war or merchant, english or pirate ship with class 2 or 3 or 4
+int GetRandomShipType(int classFlags, int typeFlags, int nationFlags) 
+{
+	int shipArr[2];
+	SetArraySize(&shipArr, GetArraySize(&ShipsTypes));
+	int shipArrScore[2];
+	SetArraySize(&shipArrScore, GetArraySize(&ShipsTypes));
+	
+	int shipCount = 0;
+	int shipTotalScore = 0;
+	string sShipFlag;
+	for (int i = 0; i < GetArraySize(&ShipsTypes); i++)
+	{
+		ref refShip;
+		makeref(refShip,ShipsTypes[i]);
+		if (CheckAttribute(refShip, "QuestShip"))
+		{
+			sShipFlag = refShip.QuestShip;
+			if (sti(sShipFlag) == 1)
+			{
+				continue;
+			}
+		}
+		
+		if (CheckAttribute(refShip, "ShipHolder"))
+		{
+			sShipFlag = refShip.ShipHolder;
+			if (sti(sShipFlag) == 1)
+			{
+				continue;
+			}
+		}
+		
+		if (CheckAttribute(refShip, "CanEncounter"))
+		{
+			sShipFlag = refShip.CanEncounter;
+			if (sti(sShipFlag) == 0)
+			{
+				continue;
+			}
+		}
+
+		
+		if (!CheckAttribute(refShip, "Class"))
+		{
+			continue;
+		}
+
+		int class = sti(refShip.Class);
+
+		if (!and(classFlags, gShipClassFlags[class]))
+		{
+			continue;
+		}
+		
+		
+		bool match = false;
+		for (int j = 0; j < SHIP_TYPE_COUNT; j++)
+		{
+			string sType = gTypeFields[j];
+			if (!CheckAttribute(refShip, "Type."+sType))
+			{
+				continue;
+			}
+			string sTypeFlag = refShip.Type.(sType);
+
+			if (sti(sTypeFlag) == 1 && and(typeFlags, gShipTypeFlags[j]))
+			{
+				match = true;
+				break;
+			}
+		}
+		
+		if (!match) 
+		{
+			continue;
+		}
+		
+		match = false;
+		for (int k = 0; k < MAX_NATIONS; k++)
+		{
+			
+			string sNation = gNationFields[k];
+			if (!CheckAttribute(refShip, "nation."+sNation))
+			{
+				continue;
+			}
+			string sNationFlag = refShip.nation.(sNation);
+			if (sti(sNationFlag) == 1 && and(nationFlags, gShipNationFlags[k]) != 0)
+			{
+				match = true;
+				break;
+			}
+		}
+		
+		if (!match) 
+		{
+			continue;
+		}
+		
+		shipArr[shipCount] = i;
+		
+		//Здесь должна появиться некая "редкость типа корабля"
+		//В массиве будет храниться накопительная редкость корабля.
+		shipArrScore[shipCount] = shipTotalScore + 1; 
+		shipTotalScore = shipTotalScore + 1;
+		shipCount++;
+	}
+
+	if (shipCount == 0) 
+	{
+		return SHIP_NOTUSED;
+	}
+	
+	//Генерируем рандомную стоимость, после чего будем искать ее в массиве shipArrScore
+	//Если найденная стоимость попадает между shipArrScore[i - 1] и shipArrScore[i] - мы выбираем корабль i
+	//Таким образом чем больше очков у корабля, тем выше вероятность его сгенерировать
+	
+	int searchScore = rand(shipArrScore[shipCount - 1])
+	
+	//Дальше двоичным поиском ищем по массиву shipArrScore, чтобы вместо n^2 поиск был бы n*log(n)
+	
+	int left = 0;
+	int right = shipCount - 1;
+	
+	int shipIdx = SHIP_NOTUSED;
+	while ((right - left) > 1)
+	{
+		int middle = (left + right) / 2;
+		if (shipArrScore[middle] == searchScore)
+		{
+			return shipArr[middle];
+		}
+		if (shipArrScore[middle] < searchScore)
+		{
+			left = middle;
+		}
+		else
+		{
+			right = middle;
+		}
+	}
+	
+	
+	//По итогу получаем что shipArrScore[left] меньше искомого, shipArrScore[right] - больше, но они соседние. Значит наш выбор - right.
+	return shipArr[right];
+}
+
+

--- a/Program/ships/ships_init.c
+++ b/Program/ships/ships_init.c
@@ -113,6 +113,7 @@ void InitShips()
 	refShip.HP										= 100;
 	refShip.SP										= 100;
 	refship.CanEncounter							= false;
+	refship.ShipHolder					            = true; 
 	refship.Type.Merchant							= false;
 	refship.Type.War								= false;
 	refShip.lowpolycrew 							= 0;
@@ -1989,6 +1990,7 @@ void InitShips()
 	
 	refship.Type.Merchant				= false;
 	refship.Type.War					= true;
+	refShip.CanEncounter				= false;
 	
 	refShip.lowpolycrew 				= 24;
 	refship.Rocking.y 					= 0.5;
@@ -2063,6 +2065,7 @@ void InitShips()
 	refShip.SP              			= 100;
 	refship.Type.Merchant				= false;
 	refship.Type.War					= true;
+	refShip.CanEncounter				= false;
 	
 	refShip.lowpolycrew 				= 24;
 	refship.Rocking.y 					= 0.5;
@@ -2137,6 +2140,7 @@ void InitShips()
 	refShip.SP              			= 100;
 	refship.Type.Merchant				= false;
 	refship.Type.War					= true;
+	refShip.CanEncounter				= false;
 	refShip.lowpolycrew 				= 28;
 
 	refship.Rocking.y 					= 0.3;
@@ -2210,6 +2214,7 @@ void InitShips()
 	refShip.SP              			= 100;
 	refship.Type.Merchant				= false;
 	refship.Type.War					= true;
+	refShip.CanEncounter				= false;
 	refShip.lowpolycrew 				= 28;
 
 	refship.Rocking.y 					= 0.3;
@@ -3041,7 +3046,6 @@ void InitShips()
 	refship.SubSeaDependWeight			= 0.6;
 	refship.TurnDependWeight			= 0.3;
 	refship.WindAgainstSpeed   			= 1.20;
-	
 	refship.CabinType          			= "Cabin_Medium"; 
 
 	refship.InertiaAccelerationX	= 5.5;	refship.InertiaBrakingX		= 5.5;
@@ -3101,7 +3105,7 @@ void InitShips()
 	refship.Type.Merchant				= false;
 	refship.Type.War					= true;
 	refship.QuestShip					= true;
-	
+	refship.ShipHolder					= true; 
 	refShip.lowpolycrew					= 12;
 
 	refship.WindAgainstSpeed   			= 1.35;
@@ -3170,7 +3174,8 @@ void InitShips()
 	refship.Type.Merchant				= false;
 	refship.Type.War					= true;
 	refShip.lowpolycrew 				= 16;
-
+	refship.QuestShip					= true; 
+	refship.ShipHolder					= true; 
 	refship.Rocking.y 					= 0.8;
 	refship.Rocking.az 					= 0.025;
 	
@@ -3243,7 +3248,7 @@ void InitShips()
 	refship.Type.Merchant				= false;
 	refship.Type.War					= true;
 	refship.QuestShip					= true; 
-
+	refship.ShipHolder					= true; 
 	refShip.lowpolycrew 				= 20;
 	
 	refship.Rocking.y 					= 0.4;
@@ -3326,7 +3331,8 @@ void InitShips()
 	refship.WindAgainstSpeed   			= 0.45;
 	refship.CabinType          			= "Cabin"; // boal 28.03.05
 	refship.DeckType           			= "Big";
-		
+	refship.QuestShip					= true; 
+	refship.ShipHolder					= true; 
 	refship.InertiaAccelerationX	= 5.0;	refship.InertiaBrakingX		= 5.0;
 	refship.InertiaAccelerationY	= 4;	refship.InertiaBrakingY		= 4;
 	refship.InertiaAccelerationZ	= 5.0;	refship.InertiaBrakingZ		= 5.0;
@@ -3387,7 +3393,8 @@ void InitShips()
 	refShip.SP              			= 100;
 	refship.Type.Merchant				= false;
 	refship.Type.War					= true;
-	
+	refship.QuestShip					= true; 
+	refship.ShipHolder					= true; 
 	refShip.lowpolycrew 				= 24;
 
 	refship.Rocking.y 					= 0.5;
@@ -3748,7 +3755,10 @@ void InitShips()
 	refShip.HP									= 54000;
 	refShip.SP									= 100;
 	refShip.CanEncounter						= false;
-
+	refship.ShipHolder					        = true; 
+	
+	makeref(refShip,ShipsTypes[SHIP_FORT + 1]);
+	refShip.ShipHolder  = true;
 	/// Check
 	for (int i=0; i<SHIP_TYPES_QUANTITY_WITH_FORT-1; i++)
 	{


### PR DESCRIPTION
По замыслу, теперь мы должны не быть привязаны к порядковому номеру типа корабля. И если захотим, сможем добавить корабль просто в конец массива, после форта и заглушки с индексом `SHIP_TYPES_QUANTITY + 1` (кстати, зачем она?).
И если мы добавим такой корабль и у него не будет стоять один из флагов `QuestShip`, `ShipHolder` или `CanEncounter`, то такой корабль будет добавляться в верфь и энкаунтеры.