### PR TITLE
Refactor sex events

### DIFF
--- a/Program/dialogs/english/Quest/CompanionQuests/Longway.c
+++ b/Program/dialogs/english/Quest/CompanionQuests/Longway.c
@@ -5012,6 +5012,7 @@ void ProcessDialogEvent()
 			dialog.text = "Actually, it's really easy to figure out the truth, alright, hee hee. If you haven't been with anyone, you must be full of energy right now. That's what we're going to check out now, alright!";
 			link.l1 = "Mary, please..";
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 			pchar.questTemp.PZ_MaryRazgovorOBordeli = true;
 		break;
@@ -8460,6 +8461,7 @@ void ProcessDialogEvent()
 				dialog.text = "It's alright, Charles, really. I just try not to think about it. And besides, you saved me from the worst of it. So let's stop talking and just... catch up.";
 				link.l1 = "That's a damn good idea, Helen.";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -8468,6 +8470,7 @@ void ProcessDialogEvent()
 				dialog.text = "Charles, I don't want it, I demand it, alright!";
 				link.l1 = "I wouldn't dare refuse you...";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 		break;
 		

--- a/Program/dialogs/english/Quest/LSC/Mary.c
+++ b/Program/dialogs/english/Quest/LSC/Mary.c
@@ -1538,6 +1538,7 @@ void ProcessDialogEvent()
 			dialog.text = RandPhraseSimple(""+pchar.name+", there is no a greater happiness to me than being in your arms, alright... Let's go!",""+pchar.name+", I'd like to be with you every waking moment if it were possible. Let's go!");
 			link.l1 = RandPhraseSimple("You are the best, my love...","You are wonderful, my talisman...");
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 		break;
 		
@@ -1567,6 +1568,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;//закрыть локацию
 			if (sti(pchar.money) >= 10) AddMoneyToCharacter(pchar, -10);
 			if (npchar.chr_ai.type == "actor")

--- a/Program/dialogs/english/Quest/Saga/Helena.c
+++ b/Program/dialogs/english/Quest/Saga/Helena.c
@@ -614,6 +614,7 @@ void ProcessDialogEvent()
 				dialog.text = RandPhraseSimple(""+pchar.name+", the mood is just right, let's go!",""+pchar.name+", sure, no questions asked! Let's go!");
 				link.l1 = RandPhraseSimple("That's my girl...","You are so lovely, Helen...");
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -657,6 +658,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;
 			//npchar.quest.daily_sex_room = true; // для первого раза в таверне чтобы счетчик запустить . лесник
 			//npchar.quest.daily_sex_cabin = true;

--- a/Program/dialogs/french/Quest/CompanionQuests/Longway.c
+++ b/Program/dialogs/french/Quest/CompanionQuests/Longway.c
@@ -5011,6 +5011,7 @@ void ProcessDialogEvent()
 			dialog.text = "En fait, c'est vraiment facile de découvrir la vérité, ouais, hein ? Si tu n'as été avec personne, tu dois être plein d'énergie en ce moment. C'est ce qu'on va vérifier maintenant, ouais, hein !";
 			link.l1 = "Mary, s'il te plaît...";
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 			pchar.questTemp.PZ_MaryRazgovorOBordeli = true;
 		break;
@@ -8516,6 +8517,7 @@ void ProcessDialogEvent()
 				dialog.text = "C'est bon, Charles, vraiment. J'essaie juste de ne pas y penser. Et puis, tu m'as sauvé du pire. Alors arrêtons de parler et juste... rattrapons le temps perdu.";
 				link.l1 = "C'est une sacrée bonne idée, Helen.";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -8524,6 +8526,7 @@ void ProcessDialogEvent()
 				dialog.text = "Charles, je ne le veux pas, je l'exige, ouais, hein ?";
 				link.l1 = "Je n'oserais pas vous refuser...";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 		break;
 		

--- a/Program/dialogs/french/Quest/LSC/Mary.c
+++ b/Program/dialogs/french/Quest/LSC/Mary.c
@@ -1538,6 +1538,7 @@ void ProcessDialogEvent()
 			dialog.text = RandPhraseSimple(""+pchar.name+", il n'y a pas de plus grand bonheur pour moi que d'être dans tes bras, ouais, hein... Allons-y !",""+pchar.name+"Ouais, hein ? Je voudrais être avec toi à chaque instant de la journée si c'était possible. Allons-y !");
 			link.l1 = RandPhraseSimple("Tu es le meilleur, mon amour...","Tu es merveilleux, mon talisman...");
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 		break;
 		
@@ -1567,6 +1568,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;//закрыть локацию
 			if (sti(pchar.money) >= 10) AddMoneyToCharacter(pchar, -10);
 			if (npchar.chr_ai.type == "actor")

--- a/Program/dialogs/french/Quest/Saga/Helena.c
+++ b/Program/dialogs/french/Quest/Saga/Helena.c
@@ -614,6 +614,7 @@ void ProcessDialogEvent()
 				dialog.text = RandPhraseSimple("Bonjour, monami."+pchar.name+" , l'ambiance est parfaite, allons-y !",""+pchar.name+"Bien sûr, sans poser de questions! Allons-y!");
 				link.l1 = RandPhraseSimple("C'est ma fille...","Tu es si ravissante, Hélène...");
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -657,6 +658,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;
 			//npchar.quest.daily_sex_room = true; // для первого раза в таверне чтобы счетчик запустить . лесник
 			//npchar.quest.daily_sex_cabin = true;

--- a/Program/dialogs/german/Quest/CompanionQuests/Longway.c
+++ b/Program/dialogs/german/Quest/CompanionQuests/Longway.c
@@ -5011,6 +5011,7 @@ void ProcessDialogEvent()
 			dialog.text = "Eigentlich ist es wirklich einfach, die Wahrheit herauszufinden, ja, gell, hihi. Wenn du mit niemandem zusammen warst, musst du jetzt voller Energie sein. Das werden wir jetzt überprüfen, ja, gell!";
 			link.l1 = "Mary, bitte..";
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 			pchar.questTemp.PZ_MaryRazgovorOBordeli = true;
 		break;
@@ -8458,6 +8459,7 @@ void ProcessDialogEvent()
 				dialog.text = "Es ist in Ordnung, Charles, wirklich. Ich versuche einfach, nicht darüber nachzudenken. Und außerdem hast du mich vor dem Schlimmsten bewahrt. Also lassen wir das Reden und... holen wir einfach auf.";
 				link.l1 = "Das ist eine verdammt gute Idee, Helen.";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -8466,6 +8468,7 @@ void ProcessDialogEvent()
 				dialog.text = "Charles, ich will es nicht, ich fordere es, ja, gell!";
 				link.l1 = "Ich würde es nicht wagen, Ihnen zu widersprechen...";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 		break;
 		

--- a/Program/dialogs/german/Quest/LSC/Mary.c
+++ b/Program/dialogs/german/Quest/LSC/Mary.c
@@ -1538,6 +1538,7 @@ void ProcessDialogEvent()
 			dialog.text = RandPhraseSimple(""+pchar.name+", es gibt für mich kein größeres Glück, als in deinen Armen zu sein, ja, gell... Lass uns gehen!",""+pchar.name+", Ich würde gerne jeden wachen Moment mit dir verbringen, wenn es möglich wäre. Lass uns gehen!");
 			link.l1 = RandPhraseSimple("Du bist der Beste, meine Liebe...","Du bist wunderbar, mein Talisman...");
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 		break;
 		
@@ -1567,6 +1568,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;//закрыть локацию
 			if (sti(pchar.money) >= 10) AddMoneyToCharacter(pchar, -10);
 			if (npchar.chr_ai.type == "actor")

--- a/Program/dialogs/german/Quest/Saga/Helena.c
+++ b/Program/dialogs/german/Quest/Saga/Helena.c
@@ -614,6 +614,7 @@ void ProcessDialogEvent()
 				dialog.text = RandPhraseSimple(""+pchar.name+", die Stimmung ist genau richtig, los geht's!",""+pchar.name+", sicher, keine Frage! Los geht's!");
 				link.l1 = RandPhraseSimple("Das ist mein Mädchen...","Du bist so lieblich, Helen...");
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -657,6 +658,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;
 			//npchar.quest.daily_sex_room = true; // для первого раза в таверне чтобы счетчик запустить . лесник
 			//npchar.quest.daily_sex_cabin = true;

--- a/Program/dialogs/italian/Quest/CompanionQuests/Longway.c
+++ b/Program/dialogs/italian/Quest/CompanionQuests/Longway.c
@@ -5011,6 +5011,7 @@ void ProcessDialogEvent()
 			dialog.text = "In realtà è facilissimo scoprire la verità, giusto, ehehe. Se non sei stato con nessuno, adesso devi avere un sacco di energia. Ed è proprio quello che andremo a verificare ora, giusto!";
 			link.l1 = "Mary, per favore...";
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 			pchar.questTemp.PZ_MaryRazgovorOBordeli = true;
 		break;
@@ -8458,6 +8459,7 @@ void ProcessDialogEvent()
 				dialog.text = "Va tutto bene, Charles, davvero. Cerco solo di non pensarci troppo. E poi, mi hai salvata dal peggio, giusto? Quindi smettiamola di parlarne e... pensiamo ad altro.";
 				link.l1 = "Questa sì che è un’ottima idea, Helen.";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -8466,6 +8468,7 @@ void ProcessDialogEvent()
 				dialog.text = "Charles, non lo voglio, lo pretendo, giusto!";
 				link.l1 = "Non oserei mai rifiutare, Mio Signore Capitano...";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 		break;
 		

--- a/Program/dialogs/italian/Quest/LSC/Mary.c
+++ b/Program/dialogs/italian/Quest/LSC/Mary.c
@@ -1538,6 +1538,7 @@ void ProcessDialogEvent()
 			dialog.text = RandPhraseSimple(""+pchar.name+", non c’è felicità più grande per me che stare fra le tue braccia, giusto... Andiamo!",""+pchar.name+" , vorrei starti accanto ogni attimo che respiro, se solo fosse possibile. Andiamo, giusto?");
 			link.l1 = RandPhraseSimple("Sei il migliore, amore mio... giusto?","Sei meraviglioso, il mio portafortuna... giusto?");
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 		break;
 		
@@ -1567,6 +1568,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;//закрыть локацию
 			if (sti(pchar.money) >= 10) AddMoneyToCharacter(pchar, -10);
 			if (npchar.chr_ai.type == "actor")

--- a/Program/dialogs/italian/Quest/Saga/Helena.c
+++ b/Program/dialogs/italian/Quest/Saga/Helena.c
@@ -614,6 +614,7 @@ void ProcessDialogEvent()
 				dialog.text = RandPhraseSimple(""+pchar.name+", l’atmosfera è perfetta, andiamo!",""+pchar.name+", certo, senza fare domande! Andiamo!");
 				link.l1 = RandPhraseSimple("Questa è la mia ragazza...","Sei così incantevole, Helen...");
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -657,6 +658,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;
 			//npchar.quest.daily_sex_room = true; // для первого раза в таверне чтобы счетчик запустить . лесник
 			//npchar.quest.daily_sex_cabin = true;

--- a/Program/dialogs/polish/Quest/CompanionQuests/Longway.c
+++ b/Program/dialogs/polish/Quest/CompanionQuests/Longway.c
@@ -5012,6 +5012,7 @@ void ProcessDialogEvent()
 			dialog.text = "Właściwie to naprawdę łatwo dojść do prawdy, tak, co nie? Hee hee. Jeśli z nikim nie byłeś, to musisz być pełen energii teraz. To właśnie zamierzamy teraz sprawdzić, tak, co nie?";
 			link.l1 = "Mary, proszę...";
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 			pchar.questTemp.PZ_MaryRazgovorOBordeli = true;
 		break;
@@ -8517,6 +8518,7 @@ void ProcessDialogEvent()
 				dialog.text = "„W porządku, Charles, naprawdę. Po prostu staram się o tym nie myśleć. A poza tym, uratowałeś mnie przed najgorszym. Więc przestańmy o tym rozmawiać i po prostu... nadrobić zaległości.”";
 				link.l1 = "To cholernie dobry pomysł, Helen.";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -8525,6 +8527,7 @@ void ProcessDialogEvent()
 				dialog.text = "„Charles, nie chcę tego, żądam tego, tak, co nie!”";
 				link.l1 = "Nie ośmieliłbym się ci odmówić...";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 		break;
 		

--- a/Program/dialogs/polish/Quest/LSC/Mary.c
+++ b/Program/dialogs/polish/Quest/LSC/Mary.c
@@ -1538,6 +1538,7 @@ void ProcessDialogEvent()
 			dialog.text = RandPhraseSimple(""+pchar.name+"Nie ma dla mnie większego szczęścia niż być w twoich ramionach, tak, co nie... Chodźmy!",""+pchar.name+"Tak, co nie? Chciałabym być z tobą każdą chwilę, gdyby to było możliwe. Chodźmy!");
 			link.l1 = RandPhraseSimple("Jesteś najlepszy, mój kochany...","Jesteś cudowny, mój talizmanie...");
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 		break;
 		
@@ -1567,6 +1568,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;//закрыть локацию
 			if (sti(pchar.money) >= 10) AddMoneyToCharacter(pchar, -10);
 			if (npchar.chr_ai.type == "actor")

--- a/Program/dialogs/polish/Quest/Saga/Helena.c
+++ b/Program/dialogs/polish/Quest/Saga/Helena.c
@@ -614,6 +614,7 @@ void ProcessDialogEvent()
 				dialog.text = RandPhraseSimple(""+pchar.name+", nastrój jest właśnie odpowiedni, chodźmy!",""+pchar.name+"jasne, bez żadnych pytań! Chodźmy!");
 				link.l1 = RandPhraseSimple("To moja dziewczyna...","Jesteś taka urocza, Helen...");
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -657,6 +658,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;
 			//npchar.quest.daily_sex_room = true; // для первого раза в таверне чтобы счетчик запустить . лесник
 			//npchar.quest.daily_sex_cabin = true;

--- a/Program/dialogs/russian/Quest/CompanionQuests/Longway.c
+++ b/Program/dialogs/russian/Quest/CompanionQuests/Longway.c
@@ -5056,6 +5056,7 @@ void ProcessDialogEvent()
 			dialog.text = "На самом деле, выяснить истину очень легко, хи-хи. Если ты ни с кем не был, то должен быть сейчас полон сил. Вот сейчас мы это и проверим, да!";
 			link.l1 = "Мэри...";
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 			pchar.questTemp.PZ_MaryRazgovorOBordeli = true;
 		break;
@@ -8504,6 +8505,7 @@ void ProcessDialogEvent()
 				dialog.text = "Всё хорошо, Шарль, правда. Я просто стараюсь об этом не вспоминать, вот и всё. К тому же от самого страшного ты меня спас. А теперь давай не будем трепаться почём зря и просто наверстаем упущенное.";
 				link.l1 = "Чертовски правильная мысль, Элен.";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -8512,6 +8514,7 @@ void ProcessDialogEvent()
 				dialog.text = "Шарль, я не хочу - я требую, да!";
 				link.l1 = "Не рискну тебе отказать...";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 		break;
 		

--- a/Program/dialogs/russian/Quest/LSC/Mary.c
+++ b/Program/dialogs/russian/Quest/LSC/Mary.c
@@ -1538,6 +1538,7 @@ void ProcessDialogEvent()
 			dialog.text = RandPhraseSimple(""+pchar.name+", для меня нет большей радости, чем быть в твоих объятиях, да... Пойдём!",""+pchar.name+", если бы такое было возможно - я бы вообще не расставалась с тобой ни на минуту. Пойдём!");
 			link.l1 = RandPhraseSimple("Ты - самая лучшая на свете, моя девочка...","Ты - просто прелесть, моя красавица...");
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 		break;
 		
@@ -1567,6 +1568,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;//закрыть локацию
 			if (sti(pchar.money) >= 10) AddMoneyToCharacter(pchar, -10);
 			if (npchar.chr_ai.type == "actor")

--- a/Program/dialogs/russian/Quest/Saga/Helena.c
+++ b/Program/dialogs/russian/Quest/Saga/Helena.c
@@ -613,6 +613,7 @@ void ProcessDialogEvent()
 				dialog.text = RandPhraseSimple(""+pchar.name+", я с радостью поддерживаю твоё предложение! Идём!",""+pchar.name+", ну конечно же не возражаю! Идём!");
 				link.l1 = RandPhraseSimple("Ты моя умничка...","Ты - просто прелесть, Элен...");
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -656,6 +657,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;
 			//npchar.quest.daily_sex_room = true; // для первого раза в таверне чтобы счетчик запустить . лесник
 			//npchar.quest.daily_sex_cabin = true;

--- a/Program/dialogs/spanish/Quest/CompanionQuests/Longway.c
+++ b/Program/dialogs/spanish/Quest/CompanionQuests/Longway.c
@@ -5012,6 +5012,7 @@ void ProcessDialogEvent()
 			dialog.text = "En realidad, es muy fácil descubrir la verdad, sí, ¿eh? Je je. Si no has estado con nadie, debes estar lleno de energía ahora mismo. Eso es lo que vamos a comprobar ahora, sí, ¿eh?";
 			link.l1 = "Mary, por favor...";
 			link.l1.go = "exit";
+			pchar.quest.sex_partner = Npchar.id;
 			AddDialogExitQuest("cabin_sex_go");
 			pchar.questTemp.PZ_MaryRazgovorOBordeli = true;
 		break;
@@ -8518,6 +8519,7 @@ void ProcessDialogEvent()
 				dialog.text = "Está bien, Charles, de verdad. Solo trato de no pensar en ello. Y además, me salvaste de lo peor. Así que dejemos de hablar y simplemente... pongámonos al día.";
 				link.l1 = "Esa es una maldita buena idea, Helen.";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -8526,6 +8528,7 @@ void ProcessDialogEvent()
 				dialog.text = "Charles, no lo quiero, lo exijo, sí, ¿eh?";
 				link.l1 = "No me atrevería a rechazarle...";
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 		break;
 		

--- a/Program/dialogs/spanish/Quest/LSC/Mary.c
+++ b/Program/dialogs/spanish/Quest/LSC/Mary.c
@@ -1551,6 +1551,7 @@ void ProcessDialogEvent()
 		dialog.text = RandPhraseSimple("" + pchar.name + ", no hay mayor felicidad para mí que estar en tus brazos, sí, ¿eh?... ¡Vamos!", "" + pchar.name + "Me gustaría estar contigo cada momento del día si fuera posible. ¡Vamos!");
 		link.l1 = RandPhraseSimple("Eres el mejor, mi amor...", "Eres maravilloso, mi talismán...");
 		link.l1.go = "exit";
+		pchar.quest.sex_partner = Npchar.id;
 		AddDialogExitQuest("cabin_sex_go");
 		break;
 
@@ -1580,6 +1581,7 @@ void ProcessDialogEvent()
 
 	case "room_sex_go":
 		DialogExit();
+		pchar.quest.sex_partner = Npchar.id;
 		chrDisableReloadToLocation = true; // закрыть локацию
 		if (sti(pchar.money) >= 10)
 			AddMoneyToCharacter(pchar, -10);

--- a/Program/dialogs/spanish/Quest/Saga/Helena.c
+++ b/Program/dialogs/spanish/Quest/Saga/Helena.c
@@ -614,6 +614,7 @@ void ProcessDialogEvent()
 				dialog.text = RandPhraseSimple(" "+pchar.name+", el ambiente es perfecto, ¡vamos!",""+pchar.name+", claro, ¡sin preguntas! ¡Vamos!");
 				link.l1 = RandPhraseSimple("Esa es mi chica...","Eres tan encantadora, Helen...");
 				link.l1.go = "exit";
+				pchar.quest.sex_partner = Npchar.id;
 				AddDialogExitQuest("cabin_sex_go");
 			}
 		break;
@@ -657,6 +658,7 @@ void ProcessDialogEvent()
 		
 		case "room_sex_go":
 			DialogExit();
+			pchar.quest.sex_partner = Npchar.id;
 			chrDisableReloadToLocation = true;
 			//npchar.quest.daily_sex_room = true; // для первого раза в таверне чтобы счетчик запустить . лесник
 			//npchar.quest.daily_sex_cabin = true;

--- a/Program/quests/Sharlie/HelenDrinking.c
+++ b/Program/quests/Sharlie/HelenDrinking.c
@@ -2245,6 +2245,7 @@ void Helen_GiveSexDrink() {
 void Helen_GiveSexGoToRoom(string qName) {
 	sld = CharacterFromID("Helena");
 	ChangeCharacterAddressGroup(sld, loadedLocation.fastreload + "_tavern_upstairs", "quest", "quest3");
+	pchar.quest.sex_partner = "Helena";
 	DoFunctionReloadToLocation(loadedLocation.fastreload + "_tavern_upstairs", "quest", "quest4", "GiveKissInRoom");
 }
 
@@ -2258,14 +2259,8 @@ void GiveKissInRoom()
 	LAi_SetActorType(pchar);
 	LAi_ActorAnimation(pchar, "kiss", "1", 7.5);
 	
-	if (CheckAttribute(pchar, "questTemp.LSC.Mary_officer") && GetCharacterIndex("Mary") != -1)
-	{
-		sld = characterFromId("Mary"); // Мэри
-	}
-	if (CheckAttribute(pchar, "questTemp.Saga.Helena_officer") && GetCharacterIndex("Helena") != -1)
-	{
-		sld = characterFromId("Helena"); // Элен
-	}
+	ref sld = characterFromId(pchar.quest.sex_partner);
+
 	TeleportCharacterToPosAy(sld, 0.10, 0.00, -2.10, 0.00);
 	LAi_SetActorType(sld);
 	LAi_ActorAnimation(sld, "kiss", "1", 7.5);
@@ -2286,36 +2281,27 @@ void GiveSexInRoom()
 	locCameraFollow();
 	LAi_SetPlayerType(pchar);
 	ChangeCharacterAddressGroup(pchar, PChar.location, "quest", "quest4");
-	if (CheckAttribute(pchar, "questTemp.LSC.Mary_officer") && GetCharacterIndex("Mary") != -1)
+	
+	
+	ref sld = characterFromId(pchar.quest.sex_partner);
+	
+	int addHealthQuantity = 6;
+	float addMaxHealthQuantity = 1;
+	
+	if (pchar.quest.sex_partner == "Mary")
 	{
-		sld = characterFromId("Mary"); // Мэри
-			
-		if(IsEquipCharacterByArtefact(pchar, "totem_03")) 	
-		{
-			AddCharacterHealth(pchar, 24);
-			AddCharacterMaxHealth(pchar, 2.0);
-		}
-		else 
-		{
-			AddCharacterHealth(pchar, 12);
-			AddCharacterMaxHealth(pchar, 1.0);
-		}
+		addHealthQuantity *= 2;
 	}
-	if (CheckAttribute(pchar, "questTemp.Saga.Helena_officer") && GetCharacterIndex("Helena") != -1)
+	
+	if(IsEquipCharacterByArtefact(pchar, "totem_03")) 	
 	{
-		sld = characterFromId("Helena"); // Элен
-		
-		if(IsEquipCharacterByArtefact(pchar, "totem_03")) 	
-		{
-			AddCharacterHealth(pchar, 12);
-			AddCharacterMaxHealth(pchar, 2.0);
-		}
-		else 
-		{
-			AddCharacterHealth(pchar, 6);
-			AddCharacterMaxHealth(pchar, 1.0);
-		}
+		addHealthQuantity *= 2;
+		addMaxHealthQuantity *= 2;
 	}
+	
+	AddCharacterHealth(pchar, addHealthQuantity);
+	AddCharacterMaxHealth(pchar, addMaxHealthQuantity);
+
 	ChangeCharacterAddressGroup(sld, PChar.location, "quest", "quest3");
 	sld.dialog.currentnode = "sex_after";
 	LAi_SetOfficerType(sld);
@@ -2380,14 +2366,13 @@ void GiveSexInRoom()
 		break;
 	}
 	
-	if (CheckAttribute(pchar, "questTemp.LSC.Mary_officer") && GetCharacterIndex("Mary") != -1)
+	
+	if (pchar.quest.sex_partner == "Mary")
 	{
 		pchar.quest.Mary_giveme_sex.over = "yes"; //снять прерывание
-		pchar.quest.Mary_giveme_sex1.over = "yes"; //снять прерывание лесник. 	
-			
-		sld = characterFromId("Mary"); // Мэри
+		pchar.quest.Mary_giveme_sex1.over = "yes"; //снять прерывание лесник. 
 	}
-	if (CheckAttribute(pchar, "questTemp.Saga.Helena_officer") && GetCharacterIndex("Helena") != -1)
+	if (pchar.quest.sex_partner == "Helena")
 	{
 		pchar.quest.Helen_GiveSex.win_condition.l1 = "Timer";
 		pchar.quest.Helen_GiveSex.win_condition.l1.date.day = GetAddingDataDay(0, 2, 0);
@@ -2396,8 +2381,6 @@ void GiveSexInRoom()
 		pchar.quest.Helen_GiveSex.win_condition.l2 = "Location_Type";
 		pchar.quest.Helen_GiveSex.win_condition.l2.location_type = "town";
 		pchar.quest.Helen_GiveSex.function = "Helen_GiveSex";
-		
-		sld = characterFromId("Helena"); // Элен
 	}
 	AddCharacterSkill(sld, skill, 1);
 	Log_Info(""+sld.name + StringFromKey("HelenDrinking_23") + XI_ConvertString(skill));

--- a/Program/quests/Sharlie/Saga.c
+++ b/Program/quests/Sharlie/Saga.c
@@ -7400,16 +7400,8 @@ bool Saga_QuestComplete(string sQuestName, string qname)
 		TeleportCharacterToPosAy(pchar, -0.40, 10.00, 4.60, -1.50);
 		LAi_SetActorType(pchar);
 		LAi_ActorAnimation(pchar, "kiss", "1", 16.5);
-		if (CheckAttribute(pchar, "questTemp.LSC.Mary_officer") && GetCharacterIndex("Mary") != -1)
-		{
-			sld = characterFromId("Mary");
-			DoQuestCheckDelay("Mary_LoveSex_New", 15.0);
-		}
-		if (CheckAttribute(pchar, "questTemp.Saga.Helena_officer") && GetCharacterIndex("Helena") != -1)
-		{
-			sld = characterFromId("Helena");
-			DoQuestCheckDelay("Helena_LoveSex_New", 15.0);
-		}
+		sld = characterFromId(pchar.quest.sex_partner);
+		DoQuestCheckDelay("MaryHelena_LoveSex_New", 15.0);
 		ChangeCharacterAddressGroup(sld, PChar.location, "reload", "reload1");
 		TeleportCharacterToPosAy(sld, -1.00, 10.00, 4.60, 1.50);
 		LAi_SetActorType(sld);
@@ -7432,16 +7424,8 @@ bool Saga_QuestComplete(string sQuestName, string qname)
 		TeleportCharacterToPosAy(pchar, -1.30, 20.00, -1.10, 3.00);
 		LAi_SetActorType(pchar);
 		LAi_ActorAnimation(pchar, "kiss", "1", 9.5);
-		if (CheckAttribute(pchar, "questTemp.LSC.Mary_officer") && GetCharacterIndex("Mary") != -1)
-		{
-			sld = characterFromId("Mary");
-			DoQuestCheckDelay("Mary_LoveSex_New", 9.5);
-		}
-		if (CheckAttribute(pchar, "questTemp.Saga.Helena_officer") && GetCharacterIndex("Helena") != -1)
-		{
-			sld = characterFromId("Helena");
-			DoQuestCheckDelay("Helena_LoveSex_New", 9.5);
-		}
+		sld = characterFromId(pchar.quest.sex_partner);
+		DoQuestCheckDelay("MaryHelena_LoveSex_New", 9.5);
 		ChangeCharacterAddressGroup(sld, PChar.location, "reload", "reload1");
 		TeleportCharacterToPosAy(sld, -1.30, 20.00, -1.70, 0.00);
 		LAi_SetActorType(sld);
@@ -7459,16 +7443,8 @@ bool Saga_QuestComplete(string sQuestName, string qname)
 		TeleportCharacterToPosAy(pchar, 1.50, 2.14, -3.80, -1.50);
 		LAi_SetActorType(pchar);
 		LAi_ActorAnimation(pchar, "kiss", "1", 8.5);
-		if (CheckAttribute(pchar, "questTemp.LSC.Mary_officer") && GetCharacterIndex("Mary") != -1)
-		{
-			sld = characterFromId("Mary");
-			DoQuestCheckDelay("Mary_LoveSex_New", 8.5);
-		}
-		if (CheckAttribute(pchar, "questTemp.Saga.Helena_officer") && GetCharacterIndex("Helena") != -1)
-		{
-			sld = characterFromId("Helena");
-			DoQuestCheckDelay("Helena_LoveSex_New", 8.5);
-		}
+		sld = characterFromId(pchar.quest.sex_partner);
+		DoQuestCheckDelay("MaryHelena_LoveSex_New", 8.5);
 		ChangeCharacterAddressGroup(sld, PChar.location, "reload", "reload1");
 		TeleportCharacterToPosAy(sld, 0.90, 2.14, -3.80, 1.50);
 		LAi_SetActorType(sld);
@@ -7486,16 +7462,10 @@ bool Saga_QuestComplete(string sQuestName, string qname)
 		TeleportCharacterToPosAy(pchar, -0.55, 6.06, 1.65, -1.50);
 		LAi_SetActorType(pchar);
 		LAi_ActorAnimation(pchar, "kiss", "1", 8.5);
-		if (CheckAttribute(pchar, "questTemp.LSC.Mary_officer") && GetCharacterIndex("Mary") != -1)
-		{
-			sld = characterFromId("Mary");
-			DoQuestCheckDelay("Mary_LoveSex_New", 8.5);
-		}
-		if (CheckAttribute(pchar, "questTemp.Saga.Helena_officer") && GetCharacterIndex("Helena") != -1)
-		{
-			sld = characterFromId("Helena");
-			DoQuestCheckDelay("Helena_LoveSex_New", 8.5);
-		}
+
+		sld = characterFromId(pchar.quest.sex_partner);
+		DoQuestCheckDelay("MaryHelena_LoveSex_New", 8.5);
+
 		ChangeCharacterAddressGroup(sld, PChar.location, "reload", "reload1");
 		TeleportCharacterToPosAy(sld, -1.15, 6.06, 1.65, 1.50);
 		LAi_SetActorType(sld);
@@ -7513,16 +7483,8 @@ bool Saga_QuestComplete(string sQuestName, string qname)
 		TeleportCharacterToPosAy(pchar, 1.20, 3.00, -1.40, 3.00);
 		LAi_SetActorType(pchar);
 		LAi_ActorAnimation(pchar, "kiss", "1", 7.5);
-		if (CheckAttribute(pchar, "questTemp.LSC.Mary_officer") && GetCharacterIndex("Mary") != -1)
-		{
-			sld = characterFromId("Mary");
-			DoQuestCheckDelay("Mary_LoveSex_New", 7.5);
-		}
-		if (CheckAttribute(pchar, "questTemp.Saga.Helena_officer") && GetCharacterIndex("Helena") != -1)
-		{
-			sld = characterFromId("Helena");
-			DoQuestCheckDelay("Helena_LoveSex_New", 7.5);
-		}
+		sld = characterFromId(pchar.quest.sex_partner);
+		DoQuestCheckDelay("MaryHelena_LoveSex_New", 7.5);
 		ChangeCharacterAddressGroup(sld, PChar.location, "reload", "reload1");
 		TeleportCharacterToPosAy(sld, 1.20, 3.00, -2.00, 0.00);
 		LAi_SetActorType(sld);
@@ -7535,16 +7497,8 @@ bool Saga_QuestComplete(string sQuestName, string qname)
 		TeleportCharacterToPosAy(pchar, -0.20, 6.12, 1.30, -1.50);
 		LAi_SetActorType(pchar);
 		LAi_ActorAnimation(pchar, "kiss", "1", 8.5);
-		if (CheckAttribute(pchar, "questTemp.LSC.Mary_officer") && GetCharacterIndex("Mary") != -1)
-		{
-			sld = characterFromId("Mary");
-			DoQuestCheckDelay("Mary_LoveSex_New", 8.5);
-		}
-		if (CheckAttribute(pchar, "questTemp.Saga.Helena_officer") && GetCharacterIndex("Helena") != -1)
-		{
-			sld = characterFromId("Helena");
-			DoQuestCheckDelay("Helena_LoveSex_New", 8.5);
-		}
+		sld = characterFromId(pchar.quest.sex_partner);
+		DoQuestCheckDelay("MaryHelena_LoveSex_New", 7.5);
 		ChangeCharacterAddressGroup(sld, PChar.location, "reload", "reload1");
 		TeleportCharacterToPosAy(sld, -0.80, 6.12, 1.30, 1.50);
 		LAi_SetActorType(sld);
@@ -7556,14 +7510,14 @@ bool Saga_QuestComplete(string sQuestName, string qname)
 	{
 		locCameraFromToPos(-1.88, 7.69, 3.25, true, 0.30, 5.80, 0.71);
 	}
-	else if (sQuestName == "Helena_LoveSex_New") // секс с Элен
+	else if (sQuestName == "MaryHelena_LoveSex_New") // секс с Элен
 	{
 		EndQuestMovie();
 		bDisableCharacterMenu = false;
 		LAi_SetPlayerType(pchar);
 		locCameraTarget(PChar);
 		locCameraFollow();
-		sld = CharacterFromID("Helena");
+		sld = CharacterFromID(pchar.quest.sex_partner);
 		ChangeCharacterAddressGroup(pchar, PChar.location, "reload", "reload1");
 		ChangeCharacterAddressGroup(sld, PChar.location, "reload", "reload1");
 		if (Get_My_Cabin() == "My_Cabin_Huge")
@@ -7601,6 +7555,12 @@ bool Saga_QuestComplete(string sQuestName, string qname)
 		LAi_ActorFollow(sld, pchar, "", -1);
 		LAi_SetOfficerType(sld);
 		sld.Dialog.CurrentNode = "sex_after";
+
+		if (pchar.quest.sex_partner == "Mary")
+		{
+			if (CheckAttribute(pchar, "questTemp.PZ_MaryRazgovorOBordeli")) sld.Dialog.CurrentNode = "PZ_MaryRazgovorOBordeli_Bad_17";
+		}
+		
 		if (CheckAttribute(pchar, "questTemp.PZ_DevushkaSnovaOfficer")) sld.Dialog.CurrentNode = "PZ_DevushkaSnovaOfficer_Dialog1";
 		SetLaunchFrameFormParam("", "", 0, 15);
 		SetLaunchFrameFormPic("loading\inside\censored1.tga");
@@ -7608,17 +7568,31 @@ bool Saga_QuestComplete(string sQuestName, string qname)
 		LaunchFrameForm();
 		WaitDate("", 0, 0, 0, 3, 10);
 		RecalculateJumpTable();
-		if (IsEquipCharacterByArtefact(pchar, "totem_03"))     
+		
+		int addHealthQuantity = 6;
+		float addMaxHealthQuantity = 1;
+		
+		if (pchar.quest.sex_partner == "Mary")
 		{
-			AddCharacterHealth(pchar, 12);
-			AddCharacterMaxHealth(pchar, 2.0);
+			addHealthQuantity *= 2;
 		}
-		else 
+		
+		if(IsEquipCharacterByArtefact(pchar, "totem_03")) 	
 		{
-			AddCharacterHealth(pchar, 6);
-			AddCharacterMaxHealth(pchar, 1.0);
-		} 
+			addHealthQuantity *= 2;
+			addMaxHealthQuantity *= 2;
+		}
+		
+		AddCharacterHealth(pchar, addHealthQuantity);
+		AddCharacterMaxHealth(pchar, addMaxHealthQuantity);
+		
 		LAi_SetCurHPMax(pchar);
+		
+		if (pchar.quest.sex_partner == "Mary")
+		{
+			pchar.quest.Mary_giveme_sex.over = "yes"; // снять прерывание
+			pchar.quest.Mary_giveme_sex1.over = "yes"; // снять прерывание лесник.
+		}
 	}
 	else if (sQuestName == "Helena_LoveSex") // Классический вариант
 	{
@@ -7639,73 +7613,6 @@ bool Saga_QuestComplete(string sQuestName, string qname)
 			AddCharacterMaxHealth(pchar, 1.0);
 		} 
 		LAi_SetCurHPMax(pchar);
-	}
-	else if (sQuestName == "Mary_LoveSex_New") // секс с Мэри
-	{
-		EndQuestMovie();
-		bDisableCharacterMenu = false;
-		LAi_SetPlayerType(pchar);
-		locCameraTarget(PChar);
-		locCameraFollow();
-		sld = CharacterFromID("Mary");
-		ChangeCharacterAddressGroup(pchar, PChar.location, "reload", "reload1");
-		ChangeCharacterAddressGroup(sld, PChar.location, "reload", "reload1");
-		if (Get_My_Cabin() == "My_Cabin_Huge")
-		{
-			ChangeCharacterAddressGroup(pchar, PChar.location, "rld", "aloc1");
-			ChangeCharacterAddressGroup(sld, PChar.location, "rld", "aloc2");
-		}
-		if (Get_My_Cabin() == "My_Cabin")
-		{
-			ChangeCharacterAddressGroup(pchar, PChar.location, "rld", "aloc2");
-			ChangeCharacterAddressGroup(sld, PChar.location, "rld", "aloc5");
-		}
-		if (Get_My_Cabin() == "My_Cabin_Medium2")
-		{
-			ChangeCharacterAddressGroup(pchar, PChar.location, "rld", "loc0");
-			ChangeCharacterAddressGroup(sld, PChar.location, "goto", "goto3");
-		}
-		if (Get_My_Cabin() == "My_Cabin_Medium")
-		{
-			ChangeCharacterAddressGroup(pchar, PChar.location, "rld", "aloc0");
-			ChangeCharacterAddressGroup(sld, PChar.location, "rld", "aloc2");
-		}
-		if (Get_My_Cabin() == "My_Cabin_Small")
-		{
-			ChangeCharacterAddressGroup(pchar, PChar.location, "rld", "loc1");
-			ChangeCharacterAddressGroup(sld, PChar.location, "rld", "aloc0");
-		}
-		if (Get_My_Cabin() == "My_Cabin_Memento")
-		{
-			ChangeCharacterAddressGroup(pchar, PChar.location, "rld", "aloc0");
-			ChangeCharacterAddressGroup(sld, PChar.location, "rld", "loc0");
-		}
-		LAi_SetActorType(sld);
-		LAi_ActorTurnToCharacter(sld, pchar);
-		LAi_ActorFollow(sld, pchar, "", -1);
-		LAi_SetOfficerType(sld);
-		sld.Dialog.CurrentNode = "sex_after";
-		if (CheckAttribute(pchar, "questTemp.PZ_MaryRazgovorOBordeli")) sld.Dialog.CurrentNode = "PZ_MaryRazgovorOBordeli_Bad_17";
-		if (CheckAttribute(pchar, "questTemp.PZ_DevushkaSnovaOfficer")) sld.Dialog.CurrentNode = "PZ_DevushkaSnovaOfficer_Dialog1";
-		SetLaunchFrameFormParam("", "", 0,  15);
-		SetLaunchFrameFormPic("loading\inside\censored1.tga");
-		PlayStereoSound("sex\sex" + (rand(9) + 1) + ".wav");
-		LaunchFrameForm();
-		WaitDate("", 0, 0, 0, 3, 10);
-		RecalculateJumpTable();
-		if (IsEquipCharacterByArtefact(pchar, "totem_03"))     
-		{
-			AddCharacterHealth(pchar, 24);
-			AddCharacterMaxHealth(pchar, 2.0);
-		}
-		else 
-		{
-			AddCharacterHealth(pchar, 12);
-			AddCharacterMaxHealth(pchar, 1.0);
-		}
-		LAi_SetCurHPMax(pchar);
-		pchar.quest.Mary_giveme_sex.over = "yes"; // снять прерывание
-		pchar.quest.Mary_giveme_sex1.over = "yes"; // снять прерывание лесник.
 	}
 	else if (sQuestName == "Mary_LoveSex") // Классический вариант
 	{


### PR DESCRIPTION
Небольшой рефакторинг функционала уединения Шарля с девушками. На данный момент логика задается жестко: в ветке `"cabin_sex_go"` и функции `GiveKissInRoom` проверяется кто из двоих является офицером, и в сцену помещается и анимируется именно эта девушка. Такое жесткое поведение приводит к проблемам при добавлении новых девушек, или каком-то изменении взаимоотношений между ними. Вместо этого я сделал следующее: при вызове соответствующей функции проставляется переменная `pchar.quest.sex_partner`, куда записывается та девушка, с которой нужно организовать свидание. После чего ветка `"cabin_sex_go"` и функция `GiveKissInRoom` ведут себя единообразно, забирая из `pchar.quest.sex_partner` id партнера. Да, в функциях остались проверки на специфическую логику для девушек: Мэри дает большую прибавку к здоровью, устанавливаются некоторые переменные, однако основной функционал будет работать, даже если вместо Мэри или Элен передать кого-то еще (ну или передать одну из, в случае наличия в офицерах обеих).