### PR TITLE
remove past-the-end ship

### DIFF
--- a/Program/battle_interface/BattleInterface.c
+++ b/Program/battle_interface/BattleInterface.c
@@ -1772,7 +1772,7 @@ int GetIconTextureIndexWithInserting(int idx, int startIdx)
 void InitShipsTextures(int startPos)
 {
 	ref refShip;
-	for (i = 0; i < SHIP_TYPES_QUANTITY; i++)
+	for (i = 0; i < GetArraySize(&ShipsTypes); i++)
 	{
 		makeref(refShip,ShipsTypes[i]);
 		if (CheckAttribute(refShip, "modname"))

--- a/Program/interface/utilite.c
+++ b/Program/interface/utilite.c
@@ -539,7 +539,7 @@ void FillShipList(string strAccess, ref chref)
 	int n;
 	string sShip;
 
-	for(n = 0; n < GetArraySize(&ShipsTypes) - 1; n++)
+	for(n = 0; n < GetArraySize(&ShipsTypes); n++)
 	{
 		if(CheckAttribute(ShipsTypes[n], "name"))
 		sShip = ShipsTypes[n].name;

--- a/Program/migrations/0007_remove_void_ship.c
+++ b/Program/migrations/0007_remove_void_ship.c
@@ -1,0 +1,7 @@
+
+void ApplyMigration(ref migrationState)
+{
+    int shipCount = GetArraySize(&ShipsTypes);
+	shipCount -= 1;
+	SetArraySize(&ShipsTypes, shipCount);
+}

--- a/Program/scripts/ShipsUtilites.c
+++ b/Program/scripts/ShipsUtilites.c
@@ -26,7 +26,7 @@ ref GetRealShip(int iType)
 	{
 		trace ("--- Wrong Ship Index. iType is " + iType);
 		Log_TestInfo("--- Wrong Ship Index. iType is " + iType);
-		return &ShipsTypes[SHIP_TYPES_QUANTITY + 1]; // для отлова
+		return &ShipsTypes[SHIP_BOAT]; // для отлова
 	}
 	return &RealShips[iType]; 
 }

--- a/Program/sea_ai/AIShip.c
+++ b/Program/sea_ai/AIShip.c
@@ -795,7 +795,7 @@ void Ship_Add2Sea(int iCharacterIndex, bool bFromCoast, string sFantomType, bool
 		if (MOD_BETTATESTMODE == "On") Log_Info("Ship_Add2Sea ERROR : SHIP " + iShipType + ", have no name!   NPCid = "+ rCharacter.id);
 		return;
 	}
-	if (iRealShip >= GetArraySize(&ShipsTypes) - 1)
+	if (iRealShip >= GetArraySize(&ShipsTypes))
 	{
 		Trace("Character.id = " + rCharacter.id + ", have invalid ship type = " + iShipType + ", and try load to sea");
 		return;

--- a/Program/ships/ships.h
+++ b/Program/ships/ships.h
@@ -1,6 +1,5 @@
 #define SAILS_COLOR_QUANTITY				9
-#define SHIP_TYPES_QUANTITY					57
-#define SHIP_TYPES_QUANTITY_WITH_FORT		58	// must be (SHIP_TYPES_QUANTITY + 1) 
+#define SHIP_TYPES_QUANTITY_WITH_FORT		57
 
 // "Universal"
 #define SHIP_TARTANE			0   // баркас			- 7-ой класс 	(SEFH)

--- a/Program/ships/ships_init.c
+++ b/Program/ships/ships_init.c
@@ -2,7 +2,7 @@ void InitShips()
 {
 	ref refShip;
 
-	for (int idx=0;idx<SHIP_TYPES_QUANTITY_WITH_FORT;idx++)
+	for (int idx=0;idx<GetArraySize(&ShipsTypes);idx++)
 	{
 		makeref(refShip,ShipsTypes[idx]);
 
@@ -4264,11 +4264,9 @@ void InitShips()
 	refShip.SP									= 100;
 	refShip.CanEncounter						= false;
 	refship.ShipHolder					        = true; 
-	
-	makeref(refShip,ShipsTypes[SHIP_FORT + 1]);
-	refShip.ShipHolder  = true;
+
 	/// Check
-	for (int i=0; i<SHIP_TYPES_QUANTITY_WITH_FORT-1; i++)
+	for (int i=0; i<GetArraySize(&ShipsTypes); i++)
 	{
 	  	makeref(refShip, ShipsTypes[i]);
 		if (!CheckAttribute(refShip,"Name")) { continue; }


### PR DESCRIPTION
Удалил пустой элемент массива кораблей, идущий после форта. Это какой-то древний костыль, явно утративший актуальность. Плюс убрал за ненадобностью константу с количеством кораблей, так как она не используется и может смутить непосвященного человека. Для числа кораблей нужно использовать `GetArraySize(&ShipsTypes)`, а всякие фейковые корабли отсекать проверкой флага ShipHolder или, к примеру, isFort.