### PR TITLE
Update Common_Shipyard.c

### DIFF
--- a/Program/dialogs/russian/Common_Shipyard.c
+++ b/Program/dialogs/russian/Common_Shipyard.c
@@ -1464,34 +1464,38 @@ void ProcessDialogEvent()
 		break;
 		
 		case "ship_tunning_HP_complite":
-		    AddTimeToCurrent(6, 30);
-		    shTo = &RealShips[sti(Pchar.Ship.Type)];
-		    DeleteAttribute(NPChar, "Tuning");
-		    // изменим
+			AddTimeToCurrent(6, 30);
+			shTo = &RealShips[sti(Pchar.Ship.Type)];
+			DeleteAttribute(NPChar, "Tuning");
+			// изменим
 			if(!CheckAttribute(shTo, "Bonus_HP"))
 			{
 				if(sti(shTo.Spec) == SHIP_SPEC_UNIVERSAL)
 				{
-					shTo.HP        = sti(shTo.HP) + makeint(sti(shTo.HP) * 0.35);
+					shTo.HP        = makeint(stf(shTo.HP) * 1.35);
+					shTo.BaseHP    = makeint(stf(shTo.BaseHP) * 1.35);
 				}
 				else
 				{
-					shTo.HP        = sti(shTo.HP) + makeint(sti(shTo.HP)/5);
+					shTo.HP        = makeint(stf(shTo.HP) * 1.2);
+					shTo.BaseHP    = makeint(stf(shTo.BaseHP) * 1.2);
 				}
 			}
 			else
 			{
 				if(sti(shTo.Spec) == SHIP_SPEC_UNIVERSAL)
 				{
-					shTo.HP        = makeint((sti(shTo.HP) - sti(shTo.Bonus_HP)) * 1.35 + sti(shTo.Bonus_HP));
+					shTo.HP        = makeint((stf(shTo.HP) - stf(shTo.Bonus_HP)) * 1.35 + stf(shTo.Bonus_HP));
+					shTo.BaseHP    = makeint((stf(shTo.BaseHP) - stf(shTo.Bonus_HP)) * 1.35 + stf(shTo.Bonus_HP));
 				}
 				else
 				{
-					shTo.HP        = makeint((sti(shTo.HP) - sti(shTo.Bonus_HP)) * 1.2 + sti(shTo.Bonus_HP));
+					shTo.HP        = makeint((stf(shTo.HP) - stf(shTo.Bonus_HP)) * 1.2 + stf(shTo.Bonus_HP));
+					shTo.BaseHP    = makeint((stf(shTo.BaseHP) - stf(shTo.Bonus_HP)) * 1.2 + stf(shTo.Bonus_HP));
 				}
 			}
-	        shTo.Tuning.HP = true;
-			shTo.BaseHP = sti(shTo.HP);
+			shTo.Tuning.HP = true;
+			//shTo.BaseHP = sti(shTo.HP); Этого не должно существовать
 			
 			if(!CheckAttribute(pchar, "achievment.Tuning.stage3") && CheckAttribute(shTo,"Tuning.MaxCrew") && CheckAttribute(shTo,"Tuning.HP")) 
 			{


### PR DESCRIPTION
Исправляет ошибку, из-за которой улучшение корпуса корабля на верфи Виллемстада берется от текущего значения, а не от базового. В результате чего корпус корабля становится меньше, чем должен. При низких значениях текущего корпуса улучшение работает в минус.

Не действует на уже улучшенные корабли.

При улучшении значение корпуса до базового восстановлено не будет. Оба значения будут улучшены независимо.

Пример:
Корпус без улучшения (текущий/базовый) - 1500/2000
Улучшение без мода (20%) - 1800/1800 (баг)
Улучшение с модом (20%) - 1800/2400

Если кому-то нужно, я могу на всех языках закинуть.