### PR TITLE
Поправка учёта квестовых компаньонов

### DIFF
--- a/Program/characters/characterUtilite.c
+++ b/Program/characters/characterUtilite.c
@@ -1332,7 +1332,7 @@ int GetRemovableCompanionsNumber(ref _refCharacter)
 	for(int i=0; i<COMPANION_MAX; i++)
 	{
 		cn = GetCompanionIndex(_refCharacter,i);
-		if(cn > 0 && GetShipRemovable(&characters[cn]) == true)
+		if(cn > 0 && GetRemovable(&characters[cn]))
 		{
 			qn++;
 		}

--- a/Program/scripts/officers.c
+++ b/Program/scripts/officers.c
@@ -493,7 +493,7 @@ int FindFreeRandomOfficer()
 	int Counter, OfficerIdx;
 	string OfficerId;
 	// special -->
-	if (GetCharacterMaxOfficersQty(Pchar) <= (GetOfficerPassengerQuantity(Pchar) + GetCompanionQuantity(Pchar) - 1)) return -1;
+	if (GetCharacterMaxOfficersQty(Pchar) <= (GetOfficerPassengerQuantity(Pchar) + GetRemovableCompanionsNumber(Pchar) - 1)) return -1;
 	return 1;
 }
 void LandEnc_OfficerHired()


### PR DESCRIPTION
Сейчас метод считает квестовых, а не должен.

Кроме того, этот же метод стоит использовать в учёте лимита нанятых офицеров, сейчас там считаются любые компаньоны. Типа взял сопровождение торговца =  не смог нанять офицера в таверне.